### PR TITLE
Fix packaging metadata and console entrypoint

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -1999,7 +1999,12 @@ class MessengerDocsApp:
 
 
 # --- 애플리케이션 실행 ---
-if __name__ == "__main__":
+def main():
+    """GUI 애플리케이션 진입점."""
     root = ctk.CTk()
-    app = MessengerDocsApp(root)
+    MessengerDocsApp(root)
     root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "auto_write"
+name = "auto_write_txt_to_docs"
 version = "0.1.0"
 authors = [
-  { name="Your Name", email="you@example.com" },
+  { name="122yjs" },
 ]
-description = "A small example package"
+description = "텍스트 파일 변경 내용을 Google Docs에 자동으로 기록하는 데스크톱 앱"
 readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [
@@ -17,18 +17,27 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "customtkinter",
-    "pystray",
-    "Pillow",
-    "watchdog",
-    "google-api-python-client",
-    "google-auth-httplib2",
-    "google-auth-oauthlib"
+    "customtkinter>=5.2.0",
+    "Pillow>=10.0.0",
+    "watchdog>=3.0.0",
+    "google-api-python-client>=2.100.0",
+    "google-auth-httplib2>=0.1.0",
+    "google-auth-oauthlib>=1.1.0",
+    "psutil>=5.9.5",
+    "pystray>=0.19.0",
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/yourusername/auto_write"
-"Bug Tracker" = "https://github.com/yourusername/auto_write/issues"
+"Homepage" = "https://github.com/122yjs/auto_write_txt_to_docs"
+"Bug Tracker" = "https://github.com/122yjs/auto_write_txt_to_docs/issues"
 
 [project.scripts]
-auto_write_gui = "src.main_gui:main"  # main_gui.py에 main 함수가 있다고 가정
+auto_write_gui = "main_gui:main"
+
+[tool.setuptools]
+py-modules = ["main_gui"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["src*"]
+namespaces = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ google-api-python-client>=2.100.0
 google-auth-httplib2>=0.1.0
 google-auth-oauthlib>=1.1.0
 psutil>=5.9.5
-pystray
+pystray>=0.19.0

--- a/tests/test_packaging_config.py
+++ b/tests/test_packaging_config.py
@@ -1,0 +1,37 @@
+import tomllib
+import unittest
+from pathlib import Path
+
+
+class PackagingConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.pyproject_data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        self.requirements = Path("requirements.txt").read_text(encoding="utf-8").splitlines()
+        self.main_gui_source = Path("main_gui.py").read_text(encoding="utf-8")
+
+    def test_console_script_points_to_real_entrypoint(self):
+        scripts = self.pyproject_data["project"]["scripts"]
+        self.assertEqual(scripts["auto_write_gui"], "main_gui:main")
+        self.assertIn("def main():", self.main_gui_source)
+
+    def test_project_dependencies_include_runtime_packages(self):
+        dependencies = self.pyproject_data["project"]["dependencies"]
+        self.assertIn("psutil>=5.9.5", dependencies)
+        self.assertIn("pystray>=0.19.0", dependencies)
+
+    def test_setuptools_configuration_includes_main_gui_module(self):
+        setuptools_config = self.pyproject_data["tool"]["setuptools"]
+        package_find_config = setuptools_config["packages"]["find"]
+
+        self.assertEqual(setuptools_config["py-modules"], ["main_gui"])
+        self.assertEqual(package_find_config["include"], ["src*"])
+        self.assertTrue(package_find_config["namespaces"])
+
+    def test_requirements_file_keeps_psutil_and_pystray_separate(self):
+        self.assertIn("psutil>=5.9.5", self.requirements)
+        self.assertTrue(any(line.startswith("pystray") for line in self.requirements))
+        self.assertTrue(all("psutil" not in line or "pystray" not in line for line in self.requirements))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix `pyproject.toml` metadata so the package name, URLs, and dependencies match the actual project
- Add a real `main()` entrypoint to `main_gui.py` and point the console script to `main_gui:main`
- Align `requirements.txt` with runtime dependencies used by the project
- Add packaging configuration tests to guard console script and dependency declarations

## Changed Files
- `main_gui.py`
- `pyproject.toml`
- `requirements.txt`
- `tests/test_packaging_config.py`

## Validation
- `python -m unittest tests.test_packaging_config`
- `python -m py_compile main_gui.py tests/test_packaging_config.py`
- `python -m pip install -e . --no-deps`

## Notes
- This PR is intentionally split from backend processing changes
- Editable install succeeds and registers `auto_write_gui` -> `main_gui:main`