### PR TITLE
Simplify Google auth and add in-app Docs targeting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,10 @@ ENV/
 # Distribution / packaging
 .Python
 build/
+build_release/
 develop-eggs/
 dist/
+release/
 downloads/
 eggs/
 .eggs/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,34 @@ auto_write_gui
 
 ## 🚀 실행 방법
 
+## 📦 배포 방법 (Windows)
+
+### exe + portable zip 만들기
+이 프로젝트는 Windows 기준으로 **PyInstaller onedir 빌드**를 권장합니다. `onefile`보다 의존성 누락과 실행 파일 오탐 문제가 적습니다.
+
+1. PowerShell에서 프로젝트 루트로 이동합니다.
+2. 아래 스크립트를 실행합니다.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\build_release.ps1
+```
+
+3. 빌드가 끝나면 아래 산출물이 생성됩니다.
+   - exe 폴더: `dist\MessengerDocsAutoWriter\`
+   - 배포 zip: `release\MessengerDocsAutoWriter-win64-portable.zip`
+
+### 배포물에 포함되는 내용
+- 실행 파일과 Python 런타임 의존성
+- `assets\developer_credentials.json`
+- `README.md`
+- `config.json.example`
+- `added_lines_cache.json.example`
+
+### 배포 전 확인 사항
+- `developer_credentials.json` 이 올바른 Google Cloud 프로젝트용인지 확인하세요.
+- `새 문서 만들기` / `문서 목록` 기능을 쓸 경우 같은 프로젝트에서 **Google Drive API** 도 활성화되어 있어야 합니다.
+- 첫 실행 후 생성되는 `token.json` 은 사용자 PC의 `%APPDATA%\\MessengerDocsAutoWriter\\cache\\` 아래에 저장됩니다.
+
 ## 라이선스
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -44,10 +44,27 @@ auto_write_gui
 
 ### 👤 일반 사용자 사용법
 1. 프로그램을 실행합니다.
-2. **'감시 시작'** 버튼을 누릅니다.
-3. 웹 브라우저가 자동으로 열리면 사용하실 **Google 계정으로 로그인**합니다.
-4. "이 프로그램이 Google Docs에 접근하려고 합니다"라는 메시지가 나오면 **'허용'**을 눌러주세요.
-5. 한 번만 인증하면 이후에는 자동으로 작동합니다. (`token.json` 파일이 생성됩니다)
+2. 대상 문서는 아래 3가지 방식 중 하나로 지정합니다.
+   - **`새 문서 만들기`**: 현재 권한 범위에서 새 Google Docs 문서를 만들고 자동으로 연결합니다.
+   - **`기존 주소 입력`**: 기존 Google Docs URL 또는 문서 ID를 직접 입력합니다.
+   - **`문서 목록`**: 이 앱이 이미 접근 가능한 문서 목록에서 선택합니다.
+3. **`감시 시작`** 버튼을 누릅니다.
+4. 웹 브라우저가 자동으로 열리면 사용하실 **Google 계정으로 로그인**합니다.
+5. "이 프로그램이 Google Docs에 접근하려고 합니다"라는 메시지가 나오면 **`허용`**을 눌러주세요.
+6. 한 번만 인증하면 이후에는 자동으로 작동합니다. (`token.json` 파일이 생성됩니다)
+
+### 📝 문서 지정 방식 안내
+- **`새 문서 만들기`**: 가장 간단한 방식입니다. 새 문서를 만든 뒤 자동으로 현재 대상 문서로 설정합니다.
+- **`기존 주소 입력`**: 이미 쓰고 있는 Google Docs 문서가 있으면 URL 전체 또는 문서 ID만 붙여넣을 수 있습니다.
+- **`문서 목록`**: 현재 OAuth 권한이 `drive.file`이므로, **이 앱이 만들었거나 이 앱이 이미 접근한 문서만** 표시됩니다. 내 Google Drive의 모든 문서가 보이는 것은 아닙니다.
+- **`Docs 웹에서 열기`**: 현재 선택된 문서를 브라우저에서 바로 엽니다.
+
+### ⚠️ 문서 생성/문서 목록 기능 추가 조건
+- **`새 문서 만들기`** 와 **`문서 목록`** 기능은 **Google Drive API**가 활성화되어 있어야 합니다.
+- Google Docs API만 켜져 있고 Drive API가 꺼져 있으면 403 오류(`accessNotConfigured`)가 발생합니다.
+- 같은 Google Cloud 프로젝트에서 아래 두 API가 모두 활성화되어 있어야 합니다.
+  - Google Docs API
+  - Google Drive API
 
 ### 💻 개발자/배포자 설정
 프로그램을 새로 빌드하거나 다른 프로젝트로 배포하려는 경우에만 이 단계를 따르세요.
@@ -57,7 +74,8 @@ auto_write_gui
     *   JSON 파일을 다운로드하여 이름을 `developer_credentials.json`으로 변경합니다.
 2.  **파일 위치**:
     *   **소스 실행 시**: `src/auto_write_txt_to_docs/assets/developer_credentials.json` 에 배치합니다.
-    *   **빌드 시**: PyInstaller 등 빌드 도구를 사용할 때 `assets` 폴더가 포함되도록 설정합니다. (예: `--add-data "src/auto_write_txt_to_docs/assets:assets"`)
+    *   **일반 사용자 override**: 사용자가 GUI의 인증 마법사로 JSON을 다시 지정하면 사용자 설정 폴더(`AppData\\Roaming\\MessengerDocsAutoWriter`)에 별도 저장되어 그 파일이 우선 사용됩니다.
+    *   **빌드 시**: 패키징 결과물에 `src/auto_write_txt_to_docs/assets/*.json` 이 포함되도록 유지해야 합니다.
 3.  **주의**: `developer_credentials.json`과 생성된 `token.json`은 절대 공개된 저장소(GitHub 등)에 공유하지 마세요. (이미 `.gitignore`에 등록되어 있습니다.)
 
 ---

--- a/main_gui.py
+++ b/main_gui.py
@@ -26,8 +26,9 @@ try:
     # Docs 기록 기능 버전의 backend_processor 임포트
     from src.auto_write_txt_to_docs.backend_processor import run_monitoring
 except ImportError:
-    messagebox.showerror("모듈 오류", "백엔드 처리 모듈(backend_processor.py)을 찾을 수 없습니다.")
-    run_monitoring = None # 함수 부재 처리
+    # ⚠️ 수정: 모듈 레벨에서 root 없이 messagebox 호출하면 불안정 → logging으로 교체
+    logging.error("백엔드 처리 모듈(backend_processor.py)을 찾을 수 없습니다.")
+    run_monitoring = None  # 함수 부재 처리
 
 try:
     from src.auto_write_txt_to_docs.google_auth import (
@@ -36,7 +37,7 @@ try:
         list_accessible_google_documents,
     )
 except ImportError:
-    messagebox.showerror("모듈 오류", "Google 인증 모듈(google_auth.py)을 찾을 수 없습니다.")
+    logging.error("Google 인증 모듈(google_auth.py)을 찾을 수 없습니다.")
     create_google_document = None
     get_google_services = None
     list_accessible_google_documents = None
@@ -52,7 +53,7 @@ try:
         get_effective_credentials_path,
     )
 except ImportError:
-    messagebox.showerror("모듈 오류", "경로 유틸리티 모듈(path_utils.py)을 찾을 수 없습니다.")
+    logging.error("경로 유틸리티 모듈(path_utils.py)을 찾을 수 없습니다.")
     BUNDLED_CREDENTIALS_FILE_STR = None
     CONFIG_FILE_STR = "config.json"
     USER_CREDENTIALS_FILE_STR = "developer_credentials.json"
@@ -69,7 +70,7 @@ try:
         save_backup_config,
     )
 except ImportError:
-    messagebox.showerror("모듈 오류", "설정 관리 모듈(config_manager.py)을 찾을 수 없습니다.")
+    logging.error("설정 관리 모듈(config_manager.py)을 찾을 수 없습니다.")
     load_app_config = None
     load_backup_config = None
     normalize_config_data = None
@@ -79,7 +80,7 @@ except ImportError:
 try:
     from src.auto_write_txt_to_docs.ui_helpers import center_window, show_backup_restore_dialog
 except ImportError:
-    messagebox.showerror("모듈 오류", "UI 헬퍼 모듈(ui_helpers.py)을 찾을 수 없습니다.")
+    logging.error("UI 헬퍼 모듈(ui_helpers.py)을 찾을 수 없습니다.")
     center_window = None
     show_backup_restore_dialog = None
 
@@ -114,11 +115,11 @@ class MessengerDocsApp:
         # --- 상단 메뉴바 생성 ---
         self._create_menubar()
 
-        # 테마 설정
-        self.appearance_mode = ctk.StringVar(value="System")
+        # 테마 설정 (⚠️ 수정: 중복 선언이었던 L137의 두 번째 선언 제거)
+        self.appearance_mode = ctk.StringVar(value="System")  # 기본값: 시스템 설정 따름
         ctk.set_appearance_mode(self.appearance_mode.get())
         ctk.set_default_color_theme("blue")
-        
+
         # 메모리 모니터링 관련 변수
         self.memory_usage = ctk.StringVar(value="메모리: 확인 중...")
         self.memory_check_interval = 10000  # 10초마다 메모리 사용량 확인
@@ -127,14 +128,11 @@ class MessengerDocsApp:
         self.watch_folder = ctk.StringVar()
         self.docs_input = ctk.StringVar()
         self.show_help_on_startup = tk.BooleanVar(value=True)  # 도움말 표시 여부
-        
+
         # 파일 필터링 관련 변수
         self.file_extensions = ctk.StringVar(value=".txt")  # 기본값: .txt 파일만 감시
         self.use_regex_filter = tk.BooleanVar(value=False)  # 정규식 필터 사용 여부
         self.regex_pattern = ctk.StringVar(value="")  # 정규식 패턴
-        
-        # 테마 관련 변수
-        self.appearance_mode = ctk.StringVar(value="System")  # 기본값: 시스템 설정 따름
 
         self.is_monitoring = False
         self.monitoring_thread = None
@@ -677,7 +675,11 @@ class MessengerDocsApp:
                                            font=ctk.CTkFont(size=12))
         self.docs_info_label.pack(side="top", anchor="e")
         
-        settings_frame = ctk.CTkFrame(main_frame); settings_frame.pack(pady=10, padx=10, fill="x"); settings_frame.configure(border_width=1)
+        # ⚠️ 수정: settings_frame을 인스턴스 변수로 저장 → disable/enable_settings_widgets에서 안전하게 참조
+        self.settings_frame = ctk.CTkFrame(main_frame)
+        self.settings_frame.pack(pady=10, padx=10, fill="x")
+        self.settings_frame.configure(border_width=1)
+        settings_frame = self.settings_frame  # 로컬 변수로도 유지 (아래 코드 호환)
         ctk.CTkLabel(settings_frame, text="설정", font=ctk.CTkFont(weight="bold")).pack(pady=(5,0)) # pady 변경
 
         # 인증 파일 안내 라벨 추가
@@ -819,18 +821,7 @@ class MessengerDocsApp:
 
         self.log_text = ctk.CTkTextbox(log_frame, state='disabled', wrap='word', height=150); self.log_text.pack(fill="both", expand=True, padx=10, pady=(0,10))
 
-        # --- 경로 저장 버튼 (설정 섹션 내부, 빠른 수동 저장) ---
-        path_save_frame = ctk.CTkFrame(settings_frame, fg_color="transparent")
-        path_save_frame.pack(fill="x", padx=10, pady=(0,10))
-
-        ctk.CTkButton(
-            path_save_frame,
-            text="경로 저장",
-            width=120,
-            command=self.save_config,
-            fg_color="#4CAF50",  # 녹색
-            hover_color="#45A049"
-        ).pack(side="right")
+        # ⚠️ 수정: "경로 저장" 버튼 제거 — "설정 저장" 버튼(control_frame)과 완전히 동일한 기능으로 중복이었음
 
     # --- 트레이 아이콘 설정 및 제어 함수 (이전과 동일) ---
     def setup_tray_icon(self):
@@ -1189,26 +1180,35 @@ class MessengerDocsApp:
                  self.log("감시 중지됨.")
              except Exception: pass # 위젯 파괴 후 예외 무시
     def disable_settings_widgets(self):
+        # ⚠️ 수정: winfo_children()[0] 인덱스 접근 → self.settings_frame 직접 참조로 안전하게 변경
         try:
-            settings_frame = self.root.winfo_children()[0].winfo_children()[0]
-            for child in settings_frame.winfo_children():
-                 if isinstance(child, ctk.CTkFrame):
-                      for widget in child.winfo_children():
-                           # 웹에서 문서를 바로 열어보는 버튼은 감시 중에도 유지
-                           if isinstance(widget, ctk.CTkButton) and widget.cget("text") == "Docs 웹에서 열기":
-                               continue
-                           elif isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
-                               widget.configure(state="disabled")
-        except (IndexError, AttributeError): pass # 위젯 구조 변경 또는 창 파괴 시 오류 무시
+            if not hasattr(self, 'settings_frame') or not self.settings_frame.winfo_exists():
+                return
+            for child in self.settings_frame.winfo_children():
+                if isinstance(child, ctk.CTkFrame):
+                    for widget in child.winfo_children():
+                        # 웹에서 문서를 바로 열어보는 버튼은 감시 중에도 유지
+                        if isinstance(widget, ctk.CTkButton) and widget.cget("text") == "Docs 웹에서 열기":
+                            continue
+                        elif isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
+                            widget.configure(state="disabled")
+        except AttributeError:
+            pass  # 위젯 파괴 후 예외 무시
+
     def enable_settings_widgets(self):
+        # ⚠️ 수정: winfo_children()[0] 인덱스 접근 → self.settings_frame 직접 참조로 안전하게 변경
         try:
-             if not self.root.winfo_exists(): return
-             settings_frame = self.root.winfo_children()[0].winfo_children()[0]
-             for child in settings_frame.winfo_children():
-                  if isinstance(child, ctk.CTkFrame):
-                       for widget in child.winfo_children():
-                            if isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)): widget.configure(state="normal")
-        except (IndexError, AttributeError): pass
+            if not self.root.winfo_exists():
+                return
+            if not hasattr(self, 'settings_frame') or not self.settings_frame.winfo_exists():
+                return
+            for child in self.settings_frame.winfo_children():
+                if isinstance(child, ctk.CTkFrame):
+                    for widget in child.winfo_children():
+                        if isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
+                            widget.configure(state="normal")
+        except AttributeError:
+            pass
 
     def show_help_dialog(self):
         """초기 실행 시 도움말 표시"""

--- a/main_gui.py
+++ b/main_gui.py
@@ -29,6 +29,18 @@ except ImportError:
     messagebox.showerror("모듈 오류", "백엔드 처리 모듈(backend_processor.py)을 찾을 수 없습니다.")
     run_monitoring = None # 함수 부재 처리
 
+try:
+    from src.auto_write_txt_to_docs.google_auth import (
+        create_google_document,
+        get_google_services,
+        list_accessible_google_documents,
+    )
+except ImportError:
+    messagebox.showerror("모듈 오류", "Google 인증 모듈(google_auth.py)을 찾을 수 없습니다.")
+    create_google_document = None
+    get_google_services = None
+    list_accessible_google_documents = None
+
 # path_utils 임포트 (공통 경로 정책 사용)
 try:
     from src.auto_write_txt_to_docs.path_utils import (
@@ -77,6 +89,19 @@ def extract_google_id_from_url(url_or_id):
     if not url_or_id or not isinstance(url_or_id, str): return url_or_id
     match_docs = re.search(r'/document/d/([a-zA-Z0-9-_]+)', url_or_id)
     return match_docs.group(1) if match_docs else url_or_id
+
+
+def format_google_modified_time(modified_time_text):
+    """Google Drive 수정 시각 문자열을 사용자에게 읽기 쉬운 형식으로 변환한다."""
+    if not modified_time_text:
+        return "수정 시각 정보 없음"
+
+    try:
+        normalized_text = modified_time_text.replace("Z", "+00:00")
+        parsed_time = datetime.fromisoformat(normalized_text)
+        return parsed_time.strftime("%Y-%m-%d %H:%M")
+    except ValueError:
+        return modified_time_text
 
 class MessengerDocsApp:
     def __init__(self, root):
@@ -344,7 +369,7 @@ class MessengerDocsApp:
         
         # Google Docs URL/ID 검사
         if not docs_input_val:
-            errors.append("Google Docs URL 또는 ID를 입력해주세요.")
+            errors.append("Google Docs URL/ID를 입력하거나 '새 문서 만들기' 또는 '문서 목록'으로 문서를 지정해주세요.")
         else:
             docs_id = extract_google_id_from_url(docs_input_val)
             if not docs_id:
@@ -412,6 +437,190 @@ class MessengerDocsApp:
         except Exception as e:
             self.log(f"오류: Google Docs 문서 열기 실패 - {e}")
             messagebox.showerror("오류", f"Google Docs 문서 열기 실패:\n{e}", parent=self.root)
+
+    def focus_existing_docs_input(self):
+        """기존 Google Docs URL/ID를 직접 입력할 수 있도록 입력칸에 포커스를 준다."""
+        if hasattr(self, "docs_input_entry"):
+            self.docs_input_entry.focus_set()
+            self.docs_input_entry.icursor(ctk.END)
+        self.log("기존 Google Docs 주소/ID 직접 입력 모드.")
+
+    def get_google_services_for_ui(self):
+        """GUI에서 문서 생성/선택에 사용할 Google 서비스 객체를 준비한다."""
+        if not get_google_services:
+            messagebox.showerror("모듈 오류", "Google 인증 모듈을 불러오지 못했습니다.", parent=self.root)
+            return None
+
+        self.log("Google Docs/Drive 서비스 연결 확인 중...")
+        services = get_google_services(self.log)
+        if not services:
+            messagebox.showerror(
+                "Google 연결 오류",
+                "Google 인증 또는 서비스 초기화에 실패했습니다.\n로그를 확인한 뒤 다시 시도하세요.",
+                parent=self.root
+            )
+            return None
+
+        if 'docs' not in services or 'drive' not in services:
+            messagebox.showerror(
+                "Google 연결 오류",
+                "문서 생성/선택에 필요한 Google Docs 또는 Drive 서비스가 준비되지 않았습니다.",
+                parent=self.root
+            )
+            return None
+
+        return services
+
+    def create_new_google_doc(self):
+        """현재 권한 범위에서 새 Google Docs 문서를 만들고 자동으로 선택한다."""
+        if not create_google_document:
+            messagebox.showerror("모듈 오류", "문서 생성 기능을 불러오지 못했습니다.", parent=self.root)
+            return
+
+        title_dialog = ctk.CTkInputDialog(
+            text="새 Google Docs 문서 제목을 입력하세요.\n비워두면 자동 제목을 사용합니다.",
+            title="새 Google Docs 문서 만들기"
+        )
+        document_title = title_dialog.get_input()
+        if document_title is None:
+            return
+
+        services = self.get_google_services_for_ui()
+        if not services:
+            return
+
+        created_document = create_google_document(self.log, document_title, services=services)
+        if not created_document:
+            messagebox.showerror("문서 생성 실패", "새 Google Docs 문서를 만들지 못했습니다.\n로그를 확인하세요.", parent=self.root)
+            return
+
+        document_id = created_document.get("id", "")
+        document_name = created_document.get("name", "새 Google Docs 문서")
+        self.docs_input.set(document_id)
+        self.log(f"새 문서를 현재 대상 문서로 설정했습니다: {document_name} ({document_id})")
+
+        open_created_document = messagebox.askyesno(
+            "문서 생성 완료",
+            f"새 문서가 생성되었습니다.\n\n제목: {document_name}\n문서 ID: {document_id}\n\n지금 브라우저에서 열까요?",
+            parent=self.root
+        )
+        if open_created_document and created_document.get("webViewLink"):
+            webbrowser.open(created_document["webViewLink"])
+
+    def select_google_doc(self):
+        """현재 권한(drive.file)에서 접근 가능한 Google Docs 문서 목록을 표시한다."""
+        if not list_accessible_google_documents:
+            messagebox.showerror("모듈 오류", "문서 목록 기능을 불러오지 못했습니다.", parent=self.root)
+            return
+
+        services = self.get_google_services_for_ui()
+        if not services:
+            return
+
+        documents = list_accessible_google_documents(self.log, services=services, page_size=20)
+        if documents is None:
+            messagebox.showerror("문서 목록 오류", "Google Docs 문서 목록을 불러오지 못했습니다.\n로그를 확인하세요.", parent=self.root)
+            return
+
+        if not documents:
+            messagebox.showinfo(
+                "표시할 문서 없음",
+                "현재 권한(drive.file) 기준으로 이 앱이 접근 가능한 Google Docs 문서가 없습니다.\n"
+                "먼저 '새 문서 만들기'로 문서를 생성하면 이 목록에 표시됩니다.",
+                parent=self.root
+            )
+            return
+
+        selector_window = ctk.CTkToplevel(self.root)
+        selector_window.title("Google Docs 문서 목록")
+        selector_window.geometry("760x520")
+        selector_window.minsize(760, 520)
+        selector_window.transient(self.root)
+        selector_window.grab_set()
+
+        main_frame = ctk.CTkFrame(selector_window)
+        main_frame.pack(fill="both", expand=True, padx=20, pady=20)
+
+        ctk.CTkLabel(
+            main_frame,
+            text="Google Docs 문서 목록",
+            font=ctk.CTkFont(size=18, weight="bold")
+        ).pack(anchor="w", pady=(0, 8))
+
+        ctk.CTkLabel(
+            main_frame,
+            text=(
+                "현재 권한(drive.file) 기준으로 이 앱이 만들었거나 이 앱이 이미 접근 가능한 문서만 표시됩니다.\n"
+                "기존 Drive 전체 문서는 모두 보이지 않을 수 있습니다."
+            ),
+            justify="left",
+            wraplength=700
+        ).pack(anchor="w", fill="x", pady=(0, 12))
+
+        list_frame = ctk.CTkScrollableFrame(main_frame)
+        list_frame.pack(fill="both", expand=True)
+
+        def choose_document(document_info):
+            document_id = document_info.get("id", "")
+            document_name = document_info.get("name", "이름 없는 문서")
+            self.docs_input.set(document_id)
+            self.log(f"문서 목록에서 선택 완료: {document_name} ({document_id})")
+            selector_window.destroy()
+
+        for document_info in documents:
+            row_frame = ctk.CTkFrame(list_frame)
+            row_frame.pack(fill="x", padx=4, pady=4)
+
+            info_frame = ctk.CTkFrame(row_frame, fg_color="transparent")
+            info_frame.pack(side="left", fill="both", expand=True, padx=10, pady=8)
+
+            document_name = document_info.get("name", "이름 없는 문서")
+            modified_time = format_google_modified_time(document_info.get("modifiedTime"))
+            ctk.CTkLabel(
+                info_frame,
+                text=document_name,
+                font=ctk.CTkFont(weight="bold"),
+                anchor="w",
+                justify="left"
+            ).pack(anchor="w", fill="x")
+            ctk.CTkLabel(
+                info_frame,
+                text=f"최근 수정: {modified_time}\n문서 ID: {document_info.get('id', '')}",
+                justify="left",
+                anchor="w"
+            ).pack(anchor="w", fill="x", pady=(2, 0))
+
+            ctk.CTkButton(
+                row_frame,
+                text="선택",
+                width=70,
+                command=lambda doc=document_info: choose_document(doc)
+            ).pack(side="right", padx=(6, 10), pady=10)
+
+            if document_info.get("webViewLink"):
+                ctk.CTkButton(
+                    row_frame,
+                    text="열기",
+                    width=70,
+                    command=lambda url=document_info["webViewLink"]: webbrowser.open(url)
+                ).pack(side="right", padx=6, pady=10)
+
+        ctk.CTkButton(
+            main_frame,
+            text="닫기",
+            width=100,
+            command=selector_window.destroy
+        ).pack(anchor="e", pady=(12, 0))
+
+        if center_window:
+            center_window(selector_window)
+        else:
+            selector_window.update_idletasks()
+            width = selector_window.winfo_width()
+            height = selector_window.winfo_height()
+            x = (selector_window.winfo_screenwidth() // 2) - (width // 2)
+            y = (selector_window.winfo_screenheight() // 2) - (height // 2)
+            selector_window.geometry(f"{width}x{height}+{x}+{y}")
     
     def update_status(self, status_text, detail_text=None):
         """상태 표시 업데이트 (상세 내용 추가 가능)"""
@@ -503,21 +712,37 @@ class MessengerDocsApp:
         
         # Credentials 파일은 이제 자동으로 path_utils에서 관리됩니다
         
-        # Google Docs URL/ID 설정
-        docs_frame = ctk.CTkFrame(settings_frame, fg_color="transparent"); docs_frame.pack(fill="x", padx=10, pady=(5,10))
-        ctk.CTkLabel(docs_frame, text="Google Docs URL/ID:", width=120).pack(side="left", padx=(0,5))
-        ctk.CTkEntry(docs_frame, textvariable=self.docs_input).pack(side="left", fill="x", expand=True, padx=5)
-        
-        # 웹에서 열기 버튼 (아이콘 추가 및 스타일 개선)
-        docs_button = ctk.CTkButton(
-            docs_frame, 
-            text="문서 열기", 
-            width=80, 
-            command=self.open_docs_in_browser,
-            fg_color="#4285F4",  # Google 파란색
-            hover_color="#3367D6"  # 어두운 파란색
-        )
-        docs_button.pack(side="left", padx=(5,0))
+        # Google Docs 대상 문서 설정
+        docs_action_frame = ctk.CTkFrame(settings_frame, fg_color="transparent"); docs_action_frame.pack(fill="x", padx=10, pady=(5,5))
+        ctk.CTkLabel(docs_action_frame, text="문서 지정:", width=120).pack(side="left", padx=(0,5))
+
+        ctk.CTkButton(
+            docs_action_frame,
+            text="새 문서 만들기",
+            width=110,
+            command=self.create_new_google_doc,
+            fg_color="#0F9D58",
+            hover_color="#0B8043"
+        ).pack(side="left", padx=(5,0))
+
+        ctk.CTkButton(
+            docs_action_frame,
+            text="기존 주소 입력",
+            width=110,
+            command=self.focus_existing_docs_input
+        ).pack(side="left", padx=(5,0))
+
+        docs_frame = ctk.CTkFrame(settings_frame, fg_color="transparent"); docs_frame.pack(fill="x", padx=10, pady=(0,10))
+        ctk.CTkLabel(docs_frame, text="기존 주소/ID:", width=120).pack(side="left", padx=(0,5))
+        self.docs_input_entry = ctk.CTkEntry(docs_frame, textvariable=self.docs_input)
+        self.docs_input_entry.pack(side="left", fill="x", expand=True, padx=5)
+
+        ctk.CTkButton(
+            docs_frame,
+            text="문서 목록",
+            width=90,
+            command=self.select_google_doc
+        ).pack(side="left", padx=(5,0))
         
         # 제어 버튼 프레임
         control_frame = ctk.CTkFrame(main_frame, fg_color="transparent"); control_frame.pack(pady=10, fill="x")
@@ -969,8 +1194,8 @@ class MessengerDocsApp:
             for child in settings_frame.winfo_children():
                  if isinstance(child, ctk.CTkFrame):
                       for widget in child.winfo_children():
-                           # "웹에서 열기" 버튼은 항상 활성화 상태로 유지
-                           if isinstance(widget, ctk.CTkButton) and widget.cget("text") == "웹에서 열기":
+                           # 웹에서 문서를 바로 열어보는 버튼은 감시 중에도 유지
+                           if isinstance(widget, ctk.CTkButton) and widget.cget("text") == "Docs 웹에서 열기":
                                continue
                            elif isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
                                widget.configure(state="disabled")
@@ -1020,7 +1245,10 @@ class MessengerDocsApp:
 2. Google Docs URL/ID: 내용을 기록할 Google Docs 문서의 URL이나 ID를 입력합니다.
    - 전체 URL(https://docs.google.com/document/d/문서ID/edit)을 붙여넣거나
    - 문서 ID만 직접 입력할 수 있습니다.
-   - '웹에서 열기' 버튼을 클릭하면 현재 설정된 문서를 웹 브라우저에서 확인할 수 있습니다.
+   - '새 문서 만들기' 버튼으로 현재 권한 범위에서 새 문서를 만들고 바로 연결할 수 있습니다.
+   - '기존 주소 입력' 버튼을 누르면 기존 주소/ID 입력칸에 바로 입력할 수 있습니다.
+   - '문서 목록' 버튼으로 이 앱이 접근 가능한 문서 목록에서 선택할 수 있습니다.
+   - 'Docs 웹에서 열기' 버튼을 클릭하면 현재 설정된 문서를 웹 브라우저에서 확인할 수 있습니다.
 
 3. 설정 저장: 설정을 완료한 후 '설정 저장' 버튼을 클릭하면 다음 실행 시에도 같은 설정이 유지됩니다.
 

--- a/main_gui.py
+++ b/main_gui.py
@@ -34,15 +34,19 @@ try:
     from src.auto_write_txt_to_docs.path_utils import (
         BUNDLED_CREDENTIALS_FILE_STR,
         CONFIG_FILE_STR,
+        USER_CREDENTIALS_FILE_STR,
         LEGACY_CONFIG_FILE_STR,
         LOG_DIR_STR,
+        get_effective_credentials_path,
     )
 except ImportError:
     messagebox.showerror("모듈 오류", "경로 유틸리티 모듈(path_utils.py)을 찾을 수 없습니다.")
     BUNDLED_CREDENTIALS_FILE_STR = None
     CONFIG_FILE_STR = "config.json"
+    USER_CREDENTIALS_FILE_STR = "developer_credentials.json"
     LEGACY_CONFIG_FILE_STR = "config.json"
     LOG_DIR_STR = "logs"
+    get_effective_credentials_path = None
 
 try:
     from src.auto_write_txt_to_docs.config_manager import (
@@ -168,8 +172,8 @@ class MessengerDocsApp:
 
     def check_credentials_file(self):
         """ Google API 인증 파일 (developer_credentials.json) 존재 여부 확인 및 안내 """
-        if not BUNDLED_CREDENTIALS_FILE_STR:
-            self.log("오류: BUNDLED_CREDENTIALS_FILE_STR이 설정되지 않았습니다. path_utils.py를 확인하세요.")
+        if not BUNDLED_CREDENTIALS_FILE_STR and not USER_CREDENTIALS_FILE_STR:
+            self.log("오류: 인증 파일 경로 상수가 설정되지 않았습니다. path_utils.py를 확인하세요.")
             messagebox.showwarning(
                 "설정 오류",
                 "프로그램 내부 설정(인증 파일 경로)에 문제가 있습니다.\n개발자에게 문의하세요.",
@@ -177,24 +181,21 @@ class MessengerDocsApp:
             )
             return
 
-        # 실제 파일 존재 여부 확인
-        # BUNDLED_CREDENTIALS_FILE_STR은 절대 경로일 수도, 상대 경로일 수도 있습니다.
-        # path_utils.py의 get_bundled_credentials_path() 로직에 따라 결정됩니다.
-        # 여기서는 해당 경로 문자열을 그대로 사용합니다.
-        credentials_path = BUNDLED_CREDENTIALS_FILE_STR
+        credentials_path = str(get_effective_credentials_path()) if get_effective_credentials_path else BUNDLED_CREDENTIALS_FILE_STR
+        credential_source = "사용자 설정 폴더" if USER_CREDENTIALS_FILE_STR and credentials_path == USER_CREDENTIALS_FILE_STR else "기본 번들 경로"
 
-        # path_utils.py에서 get_bundled_credentials_path 함수가 print 하므로, 여기서도 로그를 남깁니다.
-        self.log(f"확인 중인 인증 파일 경로: {credentials_path}")
+        self.log(f"확인 중인 인증 파일 경로: {credentials_path} ({credential_source})")
 
         if not os.path.exists(credentials_path):
             self.log(f"경고: 인증 파일({credentials_path})을 찾을 수 없습니다.")
             open_wizard = messagebox.askyesno(
                 "인증 파일 누락",
-                f"Google API 인증을 위한 'developer_credentials.json' 파일을 찾을 수 없습니다.\n\n"
-                f"예상 경로: {credentials_path}\n\n"
+                "Google API 인증을 위한 'developer_credentials.json' 파일을 찾을 수 없습니다.\n\n"
+                f"사용자 설정 경로: {USER_CREDENTIALS_FILE_STR}\n"
+                f"기본 번들 경로: {BUNDLED_CREDENTIALS_FILE_STR}\n\n"
                 "프로그램 사용을 위해서는 이 파일이 필요합니다.\n"
                 "README.md 파일의 '설정' 섹션을 참고하거나,\n"
-                "바로 이어서 'Google 인증 설정 마법사'를 통해 준비할 수 있습니다.\n\n"
+                "바로 이어서 'Google 인증 설정 마법사'를 통해 사용자 설정 폴더에 복사할 수 있습니다.\n\n"
                 "설정 마법사를 지금 열어 파일을 준비하시겠습니까?",
                 parent=self.root
             )
@@ -1832,7 +1833,7 @@ class MessengerDocsApp:
                 "1) 'Google Cloud Console 열기'를 눌러 API를 활성화하고\n"
                 "   OAuth 데스크톱 애플리케이션 자격 증명(JSON)을 다운로드하세요.\n\n"
                 "2) 'JSON 파일 선택'을 눌러 다운로드한 파일을 선택하면\n"
-                "   프로그램이 자동으로 developer_credentials.json 으로 복사합니다.\n\n"
+                "   프로그램이 사용자 설정 폴더의 developer_credentials.json 으로 복사합니다.\n\n"
                 "3) 복사 후 '테스트' 결과가 성공이면 창을 닫고\n"
                 "   프로그램을 다시 실행하거나 감시를 시작하세요."
             ),
@@ -1854,20 +1855,23 @@ class MessengerDocsApp:
         console_btn.pack(fill="x", pady=5)
 
         # 결과 라벨 (상태 표시)
-        result_label = ctk.CTkLabel(frame, text="JSON 파일을 아직 선택하지 않았습니다.")
+        result_label = ctk.CTkLabel(
+            frame,
+            text=f"JSON 파일을 아직 선택하지 않았습니다.\n복사 대상: {USER_CREDENTIALS_FILE_STR}"
+        )
         result_label.pack(fill="x", pady=(10, 5))
 
-        # BUNDLED_CREDENTIALS_FILE_STR 이 None 일 가능성 대비
-        if not BUNDLED_CREDENTIALS_FILE_STR:
+        # USER_CREDENTIALS_FILE_STR 이 None 일 가능성 대비
+        if not USER_CREDENTIALS_FILE_STR:
             messagebox.showerror(
                 "경로 오류",
-                "인증 파일 기본 경로가 설정되어 있지 않습니다.\n프로그램을 다시 실행하거나 개발자에게 문의하세요.",
+                "인증 파일 저장 경로가 설정되어 있지 않습니다.\n프로그램을 다시 실행하거나 개발자에게 문의하세요.",
                 parent=wizard
             )
             wizard.destroy()
             return
 
-        credentials_target = Path(str(BUNDLED_CREDENTIALS_FILE_STR))
+        credentials_target = Path(str(USER_CREDENTIALS_FILE_STR))
 
         # JSON 선택 → 복사
         def select_and_copy_json():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ auto_write_gui = "main_gui:main"
 [tool.setuptools]
 py-modules = ["main_gui"]
 
+[tool.setuptools.package-data]
+"src.auto_write_txt_to_docs" = ["assets/*.json"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*"]

--- a/scripts/build_release.ps1
+++ b/scripts/build_release.ps1
@@ -1,0 +1,69 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$AppName = "MessengerDocsAutoWriter",
+    [switch]$SkipPyInstallerInstall
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+$BuildRoot = Join-Path $ProjectRoot "build_release"
+$DistRoot = Join-Path $ProjectRoot "dist"
+$ReleaseRoot = Join-Path $ProjectRoot "release"
+$AppDistDir = Join-Path $DistRoot $AppName
+$ZipPath = Join-Path $ReleaseRoot "$AppName-win64-portable.zip"
+$AssetSource = Join-Path $ProjectRoot "src\auto_write_txt_to_docs\assets"
+$EntryScript = Join-Path $ProjectRoot "main_gui.py"
+
+Write-Host "[1/6] Preparing build directories"
+if (Test-Path $BuildRoot) { Remove-Item $BuildRoot -Recurse -Force }
+if (Test-Path $AppDistDir) { Remove-Item $AppDistDir -Recurse -Force }
+if (Test-Path $ZipPath) { Remove-Item $ZipPath -Force }
+New-Item -ItemType Directory -Path $BuildRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $ReleaseRoot -Force | Out-Null
+
+Write-Host "[2/6] Preparing PyInstaller"
+if (-not $SkipPyInstallerInstall) {
+    & $PythonExe -m pip install --upgrade pyinstaller
+    if ($LASTEXITCODE -ne 0) { throw "PyInstaller installation failed." }
+}
+
+Write-Host "[3/6] Running PyInstaller"
+$PyInstallerArgs = @(
+    "-m", "PyInstaller",
+    "--noconfirm",
+    "--clean",
+    "--windowed",
+    "--onedir",
+    "--name", $AppName,
+    "--distpath", $DistRoot,
+    "--workpath", $BuildRoot,
+    "--specpath", $BuildRoot,
+    "--add-data", "$AssetSource;assets",
+    "--collect-all", "customtkinter",
+    "--collect-submodules", "googleapiclient",
+    "--collect-submodules", "google_auth_oauthlib",
+    "--collect-submodules", "google.auth",
+    "--collect-submodules", "PIL",
+    "--hidden-import", "pystray._win32",
+    "--hidden-import", "watchdog.observers.winapi",
+    "--hidden-import", "watchdog.observers.read_directory_changes",
+    $EntryScript
+)
+& $PythonExe @PyInstallerArgs
+if ($LASTEXITCODE -ne 0) { throw "PyInstaller build failed." }
+
+Write-Host "[4/6] Copying support files"
+Copy-Item (Join-Path $ProjectRoot "README.md") (Join-Path $AppDistDir "README.md") -Force
+Copy-Item (Join-Path $ProjectRoot "config.json.example") (Join-Path $AppDistDir "config.json.example") -Force
+Copy-Item (Join-Path $ProjectRoot "added_lines_cache.json.example") (Join-Path $AppDistDir "added_lines_cache.json.example") -Force
+
+Write-Host "[5/6] Creating portable zip"
+Compress-Archive -Path (Join-Path $AppDistDir "*") -DestinationPath $ZipPath -Force
+
+Write-Host "[6/6] Cleaning temporary build files"
+if (Test-Path $BuildRoot) { Remove-Item $BuildRoot -Recurse -Force }
+
+Write-Host "Done"
+Write-Host "EXE folder: $AppDistDir"
+Write-Host "ZIP file: $ZipPath"

--- a/src/auto_write_txt_to_docs/google_auth.py
+++ b/src/auto_write_txt_to_docs/google_auth.py
@@ -96,6 +96,18 @@ def authenticate(log_func):
         try:
             # 파일에서 출입 허가증 정보 로드 (권한 범위 SCOPES도 맞는지 확인)
             creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+            # [추가] 403 에러 방지: 토큰의 client_id 비교
+            try:
+                import json
+                with open(credentials_path, 'r', encoding='utf-8') as f:
+                    client_config = json.load(f)
+                    expected_client_id = client_config.get('installed', {}).get('client_id') or client_config.get('web', {}).get('client_id')
+                if creds.client_id != expected_client_id:
+                    log_func('경고: 앱 연결 변경됨. 기존 토큰을 폐기합니다.')
+                    auth_logger.warning('토큰 client_id 불일치.')
+                    creds = None
+            except Exception as e:
+                auth_logger.error(f'client_id 검증 실패: {e}')
             log_func("백엔드: 저장된 Google 사용자 인증 정보(토큰) 로드 성공.")
             auth_logger.info("기존 토큰 파일 로드 성공")
         except Exception as e:
@@ -172,13 +184,11 @@ def get_google_services(log_func):
 
     services = {}
     try:
-        log_func("백엔드: Google Docs 서비스 객체 생성 시도...")
-        # Docs 서비스만 생성
+        log_func("백엔드: Google Docs/Drive 서비스 객체 생성 시도...")
         services['docs'] = build('docs', 'v1', credentials=creds)
-        # 필요시 Drive 서비스도 추가 가능
-        # services['drive'] = build('drive', 'v3', credentials=creds)
-        log_func("백엔드: Google Docs 서비스 객체 생성 완료.")
-        auth_logger.info("Google 서비스 객체 생성 완료")
+        services['drive'] = build('drive', 'v3', credentials=creds)
+        log_func("백엔드: Google Docs/Drive 서비스 객체 생성 완료.")
+        auth_logger.info("Google Docs/Drive 서비스 객체 생성 완료")
         return services
     except HttpError as error:
         log_func(f"오류: Google 서비스 객체 생성 중 API 오류 발생 - {error}")
@@ -187,4 +197,70 @@ def get_google_services(log_func):
     except Exception as e:
         log_func(f"오류: Google 서비스 객체 생성 중 예외 발생 - {e}")
         auth_logger.error(f"Google 서비스 객체 생성 중 예외: {e}", exc_info=True)
+        return None
+
+
+def create_google_document(log_func, title, services=None):
+    """현재 권한 범위에서 새 Google Docs 문서를 생성한다."""
+    auth_logger = setup_google_auth_logging()
+    google_services = services or get_google_services(log_func)
+
+    if not google_services or 'drive' not in google_services:
+        log_func("오류: Google Drive 서비스를 사용할 수 없어 새 문서를 만들 수 없습니다.")
+        auth_logger.error("새 문서 생성 실패 - Drive 서비스 없음")
+        return None
+
+    document_title = (title or "").strip() or f"메신저 자동 기록 {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+    request_body = {
+        'name': document_title,
+        'mimeType': 'application/vnd.google-apps.document',
+    }
+
+    try:
+        created_document = google_services['drive'].files().create(
+            body=request_body,
+            fields='id, name, webViewLink',
+        ).execute()
+        log_func(f"백엔드: 새 Google Docs 문서 생성 완료 - {created_document.get('name')} ({created_document.get('id')})")
+        auth_logger.info(f"새 Google Docs 문서 생성 완료: {created_document}")
+        return created_document
+    except HttpError as error:
+        log_func(f"오류: 새 Google Docs 문서 생성 중 API 오류 발생 - {error}")
+        auth_logger.error(f"새 Google Docs 문서 생성 API 오류: {error}")
+        return None
+    except Exception as error:
+        log_func(f"오류: 새 Google Docs 문서 생성 중 예외 발생 - {error}")
+        auth_logger.error(f"새 Google Docs 문서 생성 예외: {error}", exc_info=True)
+        return None
+
+
+def list_accessible_google_documents(log_func, services=None, page_size=20):
+    """현재 권한 범위(drive.file)에서 접근 가능한 Google Docs 문서 목록을 조회한다."""
+    auth_logger = setup_google_auth_logging()
+    google_services = services or get_google_services(log_func)
+
+    if not google_services or 'drive' not in google_services:
+        log_func("오류: Google Drive 서비스를 사용할 수 없어 문서 목록을 가져올 수 없습니다.")
+        auth_logger.error("문서 목록 조회 실패 - Drive 서비스 없음")
+        return None
+
+    try:
+        response = google_services['drive'].files().list(
+            q="mimeType='application/vnd.google-apps.document' and trashed=false",
+            orderBy='modifiedTime desc',
+            pageSize=page_size,
+            spaces='drive',
+            fields='files(id, name, webViewLink, modifiedTime)',
+        ).execute()
+        documents = response.get('files', [])
+        log_func(f"백엔드: 접근 가능한 Google Docs 문서 {len(documents)}개 조회 완료.")
+        auth_logger.info(f"접근 가능한 Google Docs 문서 조회 완료: {len(documents)}개")
+        return documents
+    except HttpError as error:
+        log_func(f"오류: Google Docs 문서 목록 조회 중 API 오류 발생 - {error}")
+        auth_logger.error(f"Google Docs 문서 목록 조회 API 오류: {error}")
+        return None
+    except Exception as error:
+        log_func(f"오류: Google Docs 문서 목록 조회 중 예외 발생 - {error}")
+        auth_logger.error(f"Google Docs 문서 목록 조회 예외: {error}", exc_info=True)
         return None

--- a/src/auto_write_txt_to_docs/google_auth.py
+++ b/src/auto_write_txt_to_docs/google_auth.py
@@ -13,16 +13,28 @@ from googleapiclient.errors import HttpError
 try:
     # BUNDLED_CREDENTIALS_FILE_STR: 프로그램 신분증 주소
     # TOKEN_FILE_STR: 사용자 출입 허가증 저장 주소
-    from src.auto_write_txt_to_docs.path_utils import BUNDLED_CREDENTIALS_FILE_STR, TOKEN_FILE_STR
+    from src.auto_write_txt_to_docs.path_utils import (
+        BUNDLED_CREDENTIALS_FILE_STR,
+        TOKEN_FILE_STR,
+        USER_CREDENTIALS_FILE_STR,
+        get_effective_credentials_path,
+    )
 except ImportError:
     try:
         # 상대 import 시도 (패키지 내에서 실행될 때)
-        from .path_utils import BUNDLED_CREDENTIALS_FILE_STR, TOKEN_FILE_STR
+        from .path_utils import (
+            BUNDLED_CREDENTIALS_FILE_STR,
+            TOKEN_FILE_STR,
+            USER_CREDENTIALS_FILE_STR,
+            get_effective_credentials_path,
+        )
     except ImportError:
         # path_utils 파일이 없는 비상 상황 대비
         print("오류: path_utils.py 파일을 찾을 수 없습니다. Google 인증이 작동하지 않습니다.")
         BUNDLED_CREDENTIALS_FILE_STR = None
+        USER_CREDENTIALS_FILE_STR = None
         TOKEN_FILE_STR = 'token.json'  # 임시 경로
+        get_effective_credentials_path = None
 
 # 프로그램이 구글 문서에 접근할 수 있도록 '권한 범위(Scope)' 설정
 SCOPES = [
@@ -51,7 +63,10 @@ def authenticate(log_func):
     creds = None  # 출입 허가증을 담을 변수 초기화
 
     # ⭐ 1. 프로그램 신분증 파일 주소 가져오기 (path_utils에서) ⭐
-    credentials_path = BUNDLED_CREDENTIALS_FILE_STR
+    if get_effective_credentials_path:
+        credentials_path = str(get_effective_credentials_path())
+    else:
+        credentials_path = BUNDLED_CREDENTIALS_FILE_STR
     # ⭐ 2. 사용자 출입 허가증 저장 파일 주소 가져오기 (path_utils에서) ⭐
     token_path = TOKEN_FILE_STR
 
@@ -64,12 +79,16 @@ def authenticate(log_func):
 
     # 신분증 파일 존재 여부 확인
     if not os.path.exists(credentials_path):
-        error_msg = f"오류: Google 인증 파일({os.path.basename(credentials_path)})을 찾을 수 없습니다. 프로그램을 다시 설치하거나, 'assets' 폴더에 인증 파일이 있는지 확인해 주세요."
+        error_msg = (
+            f"오류: Google 인증 파일({os.path.basename(credentials_path)})을 찾을 수 없습니다. "
+            f"사용자 설정 경로({USER_CREDENTIALS_FILE_STR}) 또는 기본 번들 경로({BUNDLED_CREDENTIALS_FILE_STR})를 확인해 주세요."
+        )
         log_func(error_msg)
         auth_logger.critical(f"Credentials file missing at: {credentials_path}")
         return None
 
-    auth_logger.info(f"인증 시작 - 토큰 경로: {token_path}, 신분증 경로: {credentials_path}")
+    credential_source = "사용자 지정 인증 파일" if USER_CREDENTIALS_FILE_STR and credentials_path == USER_CREDENTIALS_FILE_STR else "번들 인증 파일"
+    auth_logger.info(f"인증 시작 - 토큰 경로: {token_path}, 신분증 경로: {credentials_path} ({credential_source})")
     log_func(f"백엔드: Google 인증 확인 중... (토큰 저장소: {token_path})")
 
     # ⭐ 3. 기존 출입 허가증(token.json)이 있는지 확인하고 불러오기 ⭐

--- a/src/auto_write_txt_to_docs/path_utils.py
+++ b/src/auto_write_txt_to_docs/path_utils.py
@@ -91,6 +91,26 @@ def get_bundled_credentials_path(filename="developer_credentials.json"):
         return base_path / "src" / "auto_write_txt_to_docs" / "assets" / filename
 
 
+def get_user_credentials_path(filename="developer_credentials.json") -> Path:
+    """사용자가 직접 지정한 OAuth 클라이언트 JSON 저장 경로를 반환합니다."""
+    return get_safe_config_path(filename, use_user_dir=True)
+
+
+def get_effective_credentials_path(
+    filename="developer_credentials.json",
+    user_credentials_path=None,
+    bundled_credentials_path=None,
+) -> Path:
+    """사용자 지정 인증 파일이 있으면 우선 사용하고, 없으면 번들 파일을 사용합니다."""
+    user_path = Path(user_credentials_path) if user_credentials_path is not None else get_user_credentials_path(filename)
+    bundled_path = Path(bundled_credentials_path) if bundled_credentials_path is not None else get_bundled_credentials_path(filename)
+
+    if user_path.exists():
+        return user_path
+
+    return bundled_path
+
+
 # --- 기본 경로 상수 ---
 PROJECT_ROOT = get_project_root()
 
@@ -116,6 +136,9 @@ LEGACY_CACHE_FILE_STR = str(LEGACY_CACHE_FILE)
 # ⭐⭐⭐ 아래 코드 추가 ⭐⭐⭐
 # 프로그램 신분증 파일의 최종 주소 (문자열 버전)
 BUNDLED_CREDENTIALS_FILE_STR = str(get_bundled_credentials_path())
+# 사용자가 직접 지정한 인증 파일 저장 경로 (문자열 버전)
+USER_CREDENTIALS_FILE = get_user_credentials_path()
+USER_CREDENTIALS_FILE_STR = str(USER_CREDENTIALS_FILE)
 # token.json (사용자 출입 허가증) 저장 경로도 명확히 정의 (google_auth.py 에서 사용)
 TOKEN_FILE_PATH = get_safe_cache_path("token.json", use_user_dir=True)  # ⭐token.json은 반드시 사용자 폴더에!⭐
 TOKEN_FILE_STR = str(TOKEN_FILE_PATH)

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -22,6 +22,38 @@ class FakeFlow:
         return self._credentials
 
 
+class FakeExecuteRequest:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def execute(self):
+        return self.payload
+
+
+class FakeDriveFilesApi:
+    def __init__(self, created_payload=None, listed_payload=None):
+        self.created_payload = created_payload or {}
+        self.listed_payload = listed_payload or {"files": []}
+        self.last_create_kwargs = None
+        self.last_list_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_create_kwargs = kwargs
+        return FakeExecuteRequest(self.created_payload)
+
+    def list(self, **kwargs):
+        self.last_list_kwargs = kwargs
+        return FakeExecuteRequest(self.listed_payload)
+
+
+class FakeDriveService:
+    def __init__(self, files_api):
+        self._files_api = files_api
+
+    def files(self):
+        return self._files_api
+
+
 class GoogleAuthTests(unittest.TestCase):
     def test_authenticate_uses_user_override_credentials_path_when_present(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -59,6 +91,71 @@ class GoogleAuthTests(unittest.TestCase):
         self.assertTrue(token_exists)
         self.assertIn("test-token", token_content)
         self.assertIn("백엔드: ✅ Google 계정 인증에 성공했습니다!", log_messages)
+
+    def test_get_google_services_builds_docs_and_drive_services(self):
+        fake_creds = object()
+        built_services = {}
+
+        def fake_build(service_name, version, credentials):
+            built_services[service_name] = (version, credentials)
+            return f"{service_name}-service"
+
+        with patch.object(google_auth, "authenticate", return_value=fake_creds), \
+             patch.object(google_auth, "build", side_effect=fake_build):
+            services = google_auth.get_google_services(lambda _msg: None)
+
+        self.assertEqual(services["docs"], "docs-service")
+        self.assertEqual(services["drive"], "drive-service")
+        self.assertEqual(built_services["docs"], ("v1", fake_creds))
+        self.assertEqual(built_services["drive"], ("v3", fake_creds))
+
+    def test_create_google_document_uses_drive_service_and_returns_document(self):
+        created_payload = {
+            "id": "doc-123",
+            "name": "테스트 문서",
+            "webViewLink": "https://docs.google.com/document/d/doc-123/edit",
+        }
+        files_api = FakeDriveFilesApi(created_payload=created_payload)
+        services = {"drive": FakeDriveService(files_api)}
+
+        created_document = google_auth.create_google_document(
+            lambda _msg: None,
+            "테스트 문서",
+            services=services,
+        )
+
+        self.assertEqual(created_document, created_payload)
+        self.assertEqual(
+            files_api.last_create_kwargs["body"]["mimeType"],
+            "application/vnd.google-apps.document",
+        )
+        self.assertEqual(files_api.last_create_kwargs["body"]["name"], "테스트 문서")
+        self.assertEqual(files_api.last_create_kwargs["fields"], "id, name, webViewLink")
+
+    def test_list_accessible_google_documents_returns_drive_file_list(self):
+        listed_payload = {
+            "files": [
+                {
+                    "id": "doc-1",
+                    "name": "문서 1",
+                    "webViewLink": "https://docs.google.com/document/d/doc-1/edit",
+                    "modifiedTime": "2026-03-04T10:00:00Z",
+                }
+            ]
+        }
+        files_api = FakeDriveFilesApi(listed_payload=listed_payload)
+        services = {"drive": FakeDriveService(files_api)}
+
+        documents = google_auth.list_accessible_google_documents(
+            lambda _msg: None,
+            services=services,
+            page_size=10,
+        )
+
+        self.assertEqual(documents, listed_payload["files"])
+        self.assertIn("mimeType='application/vnd.google-apps.document'", files_api.last_list_kwargs["q"])
+        self.assertEqual(files_api.last_list_kwargs["pageSize"], 10)
+        self.assertEqual(files_api.last_list_kwargs["orderBy"], "modifiedTime desc")
 
 
 if __name__ == "__main__":

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.auto_write_txt_to_docs import google_auth
+
+
+class FakeCredentials:
+    def __init__(self):
+        self.valid = True
+
+    def to_json(self):
+        return '{"token": "test-token"}'
+
+
+class FakeFlow:
+    def __init__(self, credentials):
+        self._credentials = credentials
+
+    def run_local_server(self, port=0):
+        return self._credentials
+
+
+class GoogleAuthTests(unittest.TestCase):
+    def test_authenticate_uses_user_override_credentials_path_when_present(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            user_credentials_path = temp_root / "user" / "developer_credentials.json"
+            bundled_credentials_path = temp_root / "assets" / "developer_credentials.json"
+            token_path = temp_root / "cache" / "token.json"
+
+            user_credentials_path.parent.mkdir(parents=True, exist_ok=True)
+            bundled_credentials_path.parent.mkdir(parents=True, exist_ok=True)
+            user_credentials_path.write_text('{"installed": {}}', encoding="utf-8")
+            bundled_credentials_path.write_text('{"installed": {}}', encoding="utf-8")
+
+            fake_credentials = FakeCredentials()
+            captured = {}
+            log_messages = []
+
+            def fake_from_client_secrets_file(path, scopes):
+                captured["path"] = path
+                captured["scopes"] = list(scopes)
+                return FakeFlow(fake_credentials)
+
+            with patch.object(google_auth, "get_effective_credentials_path", return_value=user_credentials_path), \
+                 patch.object(google_auth, "USER_CREDENTIALS_FILE_STR", str(user_credentials_path)), \
+                 patch.object(google_auth, "BUNDLED_CREDENTIALS_FILE_STR", str(bundled_credentials_path)), \
+                 patch.object(google_auth, "TOKEN_FILE_STR", str(token_path)), \
+                 patch.object(google_auth.InstalledAppFlow, "from_client_secrets_file", side_effect=fake_from_client_secrets_file):
+                credentials = google_auth.authenticate(log_messages.append)
+                token_exists = token_path.exists()
+                token_content = token_path.read_text(encoding="utf-8")
+
+        self.assertIs(credentials, fake_credentials)
+        self.assertEqual(captured["path"], str(user_credentials_path))
+        self.assertEqual(captured["scopes"], google_auth.SCOPES)
+        self.assertTrue(token_exists)
+        self.assertIn("test-token", token_content)
+        self.assertIn("백엔드: ✅ Google 계정 인증에 성공했습니다!", log_messages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_gui_docs_actions.py
+++ b/tests/test_main_gui_docs_actions.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+
+class MainGuiDocsActionsTests(unittest.TestCase):
+    def setUp(self):
+        self.source = Path("main_gui.py").read_text(encoding="utf-8")
+
+    def test_main_gui_contains_doc_creation_and_selection_actions(self):
+        self.assertIn("def create_new_google_doc", self.source)
+        self.assertIn("def select_google_doc", self.source)
+        self.assertIn('text="새 문서 만들기"', self.source)
+        self.assertIn('text="기존 주소 입력"', self.source)
+        self.assertIn('text="문서 목록"', self.source)
+        self.assertIn("create_google_document", self.source)
+        self.assertIn("list_accessible_google_documents", self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_packaging_config.py
+++ b/tests/test_packaging_config.py
@@ -22,8 +22,11 @@ class PackagingConfigTests(unittest.TestCase):
     def test_setuptools_configuration_includes_main_gui_module(self):
         setuptools_config = self.pyproject_data["tool"]["setuptools"]
         package_find_config = setuptools_config["packages"]["find"]
+        package_data_config = setuptools_config["package-data"]
 
         self.assertEqual(setuptools_config["py-modules"], ["main_gui"])
+        self.assertIn("src.auto_write_txt_to_docs", package_data_config)
+        self.assertIn("assets/*.json", package_data_config["src.auto_write_txt_to_docs"])
         self.assertEqual(package_find_config["include"], ["src*"])
         self.assertTrue(package_find_config["namespaces"])
 

--- a/tests/test_path_unification.py
+++ b/tests/test_path_unification.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+import tempfile
 
 from src.auto_write_txt_to_docs import path_utils
 
@@ -12,6 +13,8 @@ class PathUnificationTests(unittest.TestCase):
         self.assertEqual(path_utils.CONFIG_FILE.name, "config.json")
         self.assertEqual(path_utils.CACHE_FILE.parent, user_config_dir / "cache")
         self.assertEqual(path_utils.CACHE_FILE.name, "added_lines_cache.json")
+        self.assertEqual(path_utils.USER_CREDENTIALS_FILE.parent, user_config_dir)
+        self.assertEqual(path_utils.USER_CREDENTIALS_FILE.name, "developer_credentials.json")
 
     def test_path_utils_exposes_legacy_project_paths(self):
         self.assertEqual(path_utils.LEGACY_CONFIG_FILE, path_utils.PROJECT_ROOT / "config.json")
@@ -22,6 +25,8 @@ class PathUnificationTests(unittest.TestCase):
 
         self.assertIn("CONFIG_FILE_STR", source)
         self.assertIn("LOG_DIR_STR", source)
+        self.assertIn("USER_CREDENTIALS_FILE_STR", source)
+        self.assertIn("get_effective_credentials_path", source)
         self.assertNotIn('PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))', source)
         self.assertNotIn('CONFIG_FILE = os.path.join(PROJECT_ROOT, "config.json")', source)
 
@@ -34,6 +39,33 @@ class PathUnificationTests(unittest.TestCase):
         self.assertIn("PROCESSED_STATE_FILE_STR", source)
         self.assertIn("LINE_CACHE_FILE = CACHE_FILE_STR", source)
         self.assertNotIn("PROJECT_ROOT = os.path.dirname", source)
+
+    def test_effective_credentials_path_prefers_user_override(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            user_path = Path(temp_dir) / "user_credentials.json"
+            bundled_path = Path(temp_dir) / "bundled_credentials.json"
+            user_path.write_text("user", encoding="utf-8")
+            bundled_path.write_text("bundled", encoding="utf-8")
+
+            effective_path = path_utils.get_effective_credentials_path(
+                user_credentials_path=user_path,
+                bundled_credentials_path=bundled_path,
+            )
+
+        self.assertEqual(effective_path, user_path)
+
+    def test_effective_credentials_path_falls_back_to_bundled_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            user_path = Path(temp_dir) / "missing_user_credentials.json"
+            bundled_path = Path(temp_dir) / "bundled_credentials.json"
+            bundled_path.write_text("bundled", encoding="utf-8")
+
+            effective_path = path_utils.get_effective_credentials_path(
+                user_credentials_path=user_path,
+                bundled_credentials_path=bundled_path,
+            )
+
+        self.assertEqual(effective_path, bundled_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_build_script.py
+++ b/tests/test_release_build_script.py
@@ -1,0 +1,32 @@
+import unittest
+from pathlib import Path
+
+
+class ReleaseBuildScriptTests(unittest.TestCase):
+    def setUp(self):
+        self.script_source = Path("scripts/build_release.ps1").read_text(encoding="utf-8")
+
+    def test_build_script_includes_required_pyinstaller_options(self):
+        self.assertIn("--windowed", self.script_source)
+        self.assertIn("--onedir", self.script_source)
+        self.assertIn("--add-data", self.script_source)
+        self.assertIn('$AssetSource = Join-Path $ProjectRoot "src\\auto_write_txt_to_docs\\assets"', self.script_source)
+        self.assertIn('"$AssetSource;assets"', self.script_source)
+        self.assertIn("--collect-all", self.script_source)
+        self.assertIn("customtkinter", self.script_source)
+        self.assertIn("--collect-submodules", self.script_source)
+        self.assertIn("googleapiclient", self.script_source)
+        self.assertIn("google_auth_oauthlib", self.script_source)
+        self.assertIn("google.auth", self.script_source)
+
+    def test_build_script_copies_support_files_and_creates_zip(self):
+        self.assertIn("README.md", self.script_source)
+        self.assertIn("config.json.example", self.script_source)
+        self.assertIn("added_lines_cache.json.example", self.script_source)
+        self.assertIn("Compress-Archive", self.script_source)
+        self.assertIn("portable.zip", self.script_source)
+        self.assertIn("Remove-Item $BuildRoot -Recurse -Force", self.script_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 일반 사용자용 Google 인증 흐름을 단순화했습니다.
- 번들된 `developer_credentials.json`을 패키징 산출물에 포함하고, 사용자가 다시 지정한 인증 JSON은 사용자 설정 폴더에 저장되도록 바꿨습니다.
- 앱 내부에서 `새 문서 만들기`, `기존 주소 입력`, `문서 목록`으로 대상 문서를 지정할 수 있게 했습니다.
- `문서 목록`은 현재 `drive.file` 권한 범위에서 앱이 접근 가능한 문서만 표시합니다.
- Windows 배포를 위해 PyInstaller 기반 `exe`/`portable zip` 빌드 스크립트를 추가했습니다.

## Changed Files
- `main_gui.py`
- `README.md`
- `pyproject.toml`
- `scripts/build_release.ps1`
- `src/auto_write_txt_to_docs/google_auth.py`
- `src/auto_write_txt_to_docs/path_utils.py`
- `tests/test_google_auth.py`
- `tests/test_main_gui_docs_actions.py`
- `tests/test_packaging_config.py`
- `tests/test_path_unification.py`
- `tests/test_release_build_script.py`

## Validation
- `python -m unittest tests.test_release_build_script tests.test_main_gui_docs_actions tests.test_google_auth tests.test_ui_helpers tests.test_config_manager tests.test_packaging_config tests.test_path_unification tests.test_backend_processor`
- Result: 32 tests passed
- `powershell -ExecutionPolicy Bypass -File .\\scripts\\build_release.ps1 -SkipPyInstallerInstall`
- Result: build succeeded
  - `dist\\MessengerDocsAutoWriter\\`
  - `release\\MessengerDocsAutoWriter-win64-portable.zip`

## Notes
- `새 문서 만들기` / `문서 목록` 기능은 같은 Google Cloud 프로젝트에서 **Google Drive API**도 활성화되어 있어야 합니다.
- `문서 목록`은 `drive.file` 권한 제한 때문에 앱이 접근 가능한 문서만 표시됩니다.
- `token.json`은 `%APPDATA%\\MessengerDocsAutoWriter\\cache\\` 아래에 저장됩니다.
