### PR TITLE
Improve monitoring and document target UX

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -730,9 +730,9 @@ class MessengerDocsApp:
     def refresh_docs_target_ui(self):
         """문서 대상 고정 상태에 따라 입력/선택 UI를 갱신한다."""
         docs_input_val = self.docs_input.get().strip()
-        locked = bool(self.docs_target_locked.get() and docs_input_val)
-
-        if self.docs_target_locked.get() != locked:
+        locked = bool(self.docs_target_locked.get())
+        if locked and not docs_input_val:
+            locked = False
             self.docs_target_locked.set(locked)
 
         if locked:
@@ -743,7 +743,7 @@ class MessengerDocsApp:
             lock_button_hover = ("gray78", "gray34")
             lock_button_text_color = ("gray20", "gray92")
         elif docs_input_val:
-            status_text = "문서 입력 중입니다. '문서 경로 확정' 버튼을 눌러 고정하세요."
+            status_text = "문서가 입력되어 있습니다. 감시 시작 시 이 문서를 자동으로 확정합니다."
             status_color = ("#1A73E8", "#8AB4F8")
             lock_button_text = "문서 경로 확정"
             lock_button_color = "#1A73E8"
@@ -868,8 +868,6 @@ class MessengerDocsApp:
             docs_id = extract_google_id_from_url(docs_input_val)
             if not docs_id:
                 errors.append("유효한 Google Docs URL 또는 ID를 입력해주세요.")
-            elif not self.docs_target_locked.get():
-                errors.append("대상 문서를 확정하려면 '문서 경로 확정' 버튼을 눌러주세요.")
 
         try:
             self.parse_max_cache_size()
@@ -1970,7 +1968,7 @@ class MessengerDocsApp:
         self.launch_on_windows_startup.set(normalized_config.get("launch_on_windows_startup", False))
         self.watch_folder.set(normalized_config.get("watch_folder", ""))
         self.docs_input.set(normalized_config.get("docs_input", ""))
-        self.docs_target_locked.set(bool(normalized_config.get("docs_input", "").strip()))
+        self.docs_target_locked.set(False)
         self.show_help_on_startup.set(normalized_config.get("show_help_on_startup", True))
         self.show_success_notifications.set(normalized_config.get("show_success_notifications", True))
         self.play_event_sounds.set(normalized_config.get("play_event_sounds", True))
@@ -2041,6 +2039,11 @@ class MessengerDocsApp:
         google_services = self.verify_google_services_before_monitoring()
         if not google_services:
             return
+
+        if not self.docs_target_locked.get():
+            self.docs_target_locked.set(True)
+            self.refresh_docs_target_ui()
+            self.log("감시 시작을 위해 대상 문서를 자동으로 확정했습니다.")
         
         watch_folder = self.watch_folder.get().strip()
         docs_input_val = self.docs_input.get().strip()
@@ -2095,28 +2098,37 @@ class MessengerDocsApp:
             self.log("현재 감시 중 아님.")
             self.on_monitoring_stopped()
     def on_monitoring_stopped(self):
-         self.is_monitoring = False
-         self.monitoring_thread = None
-         if hasattr(self, 'root') and self.root.winfo_exists():
-             try: 
-                 self.start_button.configure(state="normal")
-                 self.stop_button.configure(state="disabled")
-                 self.enable_settings_widgets()
-                 self.update_status("준비")
-                 self.log("감시 중지됨.")
-             except Exception: pass # 위젯 파괴 후 예외 무시
+        self.is_monitoring = False
+        self.monitoring_thread = None
+        was_docs_locked = self.docs_target_locked.get() if hasattr(self, "docs_target_locked") else False
+        if was_docs_locked:
+            self.docs_target_locked.set(False)
+        if hasattr(self, 'root') and self.root.winfo_exists():
+            try:
+                self.start_button.configure(state="normal")
+                self.stop_button.configure(state="disabled")
+                self.enable_settings_widgets()
+                if was_docs_locked:
+                    self.log("감시 중지로 대상 문서 고정이 해제되었습니다.")
+                self.update_status("준비")
+                self.log("감시 중지됨.")
+            except Exception:
+                pass  # 위젯 파괴 후 예외 무시
     def disable_settings_widgets(self):
         # ⚠️ 수정: winfo_children()[0] 인덱스 접근 → self.settings_frame 직접 참조로 안전하게 변경
         try:
             if not hasattr(self, 'settings_frame') or not self.settings_frame.winfo_exists():
                 return
+            always_enabled_widgets = {
+                getattr(self, "watch_folder_open_button", None),
+            }
             for child in self.settings_frame.winfo_children():
                 if isinstance(child, ctk.CTkFrame):
                     for widget in child.winfo_children():
-                        # 웹에서 문서를 바로 열어보는 버튼은 감시 중에도 유지
-                        if isinstance(widget, ctk.CTkButton) and widget.cget("text") == "Docs 웹에서 열기":
+                        if widget in always_enabled_widgets:
+                            widget.configure(state="normal")
                             continue
-                        elif isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
+                        if isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
                             widget.configure(state="disabled")
         except AttributeError:
             pass  # 위젯 파괴 후 예외 무시
@@ -2134,6 +2146,7 @@ class MessengerDocsApp:
                         if isinstance(widget, (ctk.CTkEntry, ctk.CTkButton)):
                             widget.configure(state="normal")
             self.refresh_docs_target_ui()
+            self.update_windows_startup_ui_state()
         except AttributeError:
             pass
 

--- a/src/auto_write_txt_to_docs/main_window_ui.py
+++ b/src/auto_write_txt_to_docs/main_window_ui.py
@@ -167,7 +167,7 @@ def _build_settings_panel(ctk, parent, state_vars, callbacks, font_family):
         font=_font(ctk, 13, family=font_family),
     )
     watch_folder_entry.pack(side="left", fill="x", expand=True, padx=4)
-    ctk.CTkButton(
+    watch_folder_browse_button = ctk.CTkButton(
         folder_row,
         text="폴더 선택",
         width=88,
@@ -175,8 +175,9 @@ def _build_settings_panel(ctk, parent, state_vars, callbacks, font_family):
         corner_radius=10,
         command=callbacks["browse_folder"],
         font=_font(ctk, 12, "bold", family=font_family),
-    ).pack(side="left", padx=(8, 0))
-    ctk.CTkButton(
+    )
+    watch_folder_browse_button.pack(side="left", padx=(8, 0))
+    watch_folder_open_button = ctk.CTkButton(
         folder_row,
         text="열기",
         width=60,
@@ -187,7 +188,8 @@ def _build_settings_panel(ctk, parent, state_vars, callbacks, font_family):
         fg_color=("gray85", "gray28"),
         hover_color=("gray78", "gray34"),
         text_color=("gray20", "gray92"),
-    ).pack(side="left", padx=(8, 0))
+    )
+    watch_folder_open_button.pack(side="left", padx=(8, 0))
 
     folder_hint_row = ctk.CTkFrame(settings_frame, fg_color="transparent")
     folder_hint_row.pack(fill="x", padx=14, pady=(0, 4))
@@ -427,6 +429,8 @@ def _build_settings_panel(ctk, parent, state_vars, callbacks, font_family):
     return {
         "settings_frame": settings_frame,
         "watch_folder_entry": watch_folder_entry,
+        "watch_folder_browse_button": watch_folder_browse_button,
+        "watch_folder_open_button": watch_folder_open_button,
         "watch_folder_drop_hint_label": watch_folder_drop_hint_label,
         "max_cache_size_entry": max_cache_size_entry,
         "notification_checkbox": notification_checkbox,

--- a/tests/test_main_gui_settings_lock.py
+++ b/tests/test_main_gui_settings_lock.py
@@ -1,0 +1,296 @@
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+import main_gui
+
+
+class FakeVar:
+    def __init__(self, value=None):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class FakeWidget:
+    def __init__(self, text=None, state="normal"):
+        self.config = {"text": text, "state": state}
+        self.children = []
+        self.focused = False
+        self.cursor_position = None
+
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+    def cget(self, option):
+        return self.config.get(option)
+
+    @property
+    def state(self):
+        return self.config.get("state")
+
+    def winfo_children(self):
+        return list(self.children)
+
+    def winfo_exists(self):
+        return True
+
+    def focus_set(self):
+        self.focused = True
+
+    def icursor(self, position):
+        self.cursor_position = position
+
+
+class FakeFrame(FakeWidget):
+    pass
+
+
+class FakeButton(FakeWidget):
+    pass
+
+
+class FakeEntry(FakeWidget):
+    pass
+
+
+class FakeLabel(FakeWidget):
+    pass
+
+
+class FakeRoot:
+    def winfo_exists(self):
+        return True
+
+
+class MainGuiTestBase(unittest.TestCase):
+    def setUp(self):
+        self.fake_ctk = types.SimpleNamespace(
+            CTkFrame=FakeFrame,
+            CTkButton=FakeButton,
+            CTkEntry=FakeEntry,
+            END="end",
+            set_appearance_mode=Mock(),
+        )
+
+    def build_app(self):
+        app = main_gui.MessengerDocsApp.__new__(main_gui.MessengerDocsApp)
+        app.root = FakeRoot()
+        app.settings_frame = FakeFrame()
+        app.first_run = FakeVar(True)
+        app.launch_on_windows_startup = FakeVar(False)
+        app.watch_folder = FakeVar("")
+        app.docs_input = FakeVar("")
+        app.docs_target_locked = FakeVar(False)
+        app.show_help_on_startup = FakeVar(True)
+        app.show_success_notifications = FakeVar(True)
+        app.play_event_sounds = FakeVar(True)
+        app.file_extensions = FakeVar(".txt")
+        app.use_regex_filter = FakeVar(False)
+        app.regex_pattern = FakeVar("")
+        app.appearance_mode = FakeVar("System")
+        app.max_cache_size = FakeVar("10000")
+        app.docs_target_status_var = FakeVar("")
+        app.log = Mock()
+        app.update_status = Mock()
+        app.update_windows_startup_ui_state = Mock()
+        app.is_monitoring = False
+        app.monitoring_thread = None
+
+        app.watch_folder_entry = FakeEntry()
+        app.watch_folder_browse_button = FakeButton("폴더 선택")
+        app.watch_folder_open_button = FakeButton("열기")
+
+        app.create_doc_button = FakeButton("새 문서 만들기")
+        app.manual_doc_input_button = FakeButton("기존 문서 주소 입력")
+        app.select_doc_button = FakeButton("문서 목록")
+        app.docs_input_entry = FakeEntry()
+        app.docs_lock_button = FakeButton("문서 경로 확정")
+        app.docs_target_status_label = FakeLabel()
+        app.start_button = FakeButton("감시 시작")
+        app.stop_button = FakeButton("감시 중지", state="disabled")
+        other_button = FakeButton("다른 버튼")
+
+        folder_row = FakeFrame()
+        folder_row.children = [
+            app.watch_folder_entry,
+            app.watch_folder_browse_button,
+            app.watch_folder_open_button,
+        ]
+        docs_action_row = FakeFrame()
+        docs_action_row.children = [
+            app.create_doc_button,
+            app.manual_doc_input_button,
+            app.select_doc_button,
+        ]
+        docs_input_row = FakeFrame()
+        docs_input_row.children = [app.docs_input_entry]
+        docs_lock_row = FakeFrame()
+        docs_lock_row.children = [app.docs_target_status_label, app.docs_lock_button, other_button]
+        app.settings_frame.children = [folder_row, docs_action_row, docs_input_row, docs_lock_row]
+        app.other_button = other_button
+        return app
+
+
+class MainGuiSettingsLockTests(MainGuiTestBase):
+    def test_disable_settings_widgets_keeps_watch_folder_open_button_enabled(self):
+        app = self.build_app()
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            app.disable_settings_widgets()
+
+        self.assertEqual(app.watch_folder_entry.state, "disabled")
+        self.assertEqual(app.watch_folder_browse_button.state, "disabled")
+        self.assertEqual(app.watch_folder_open_button.state, "normal")
+        self.assertEqual(app.create_doc_button.state, "disabled")
+        self.assertEqual(app.docs_input_entry.state, "disabled")
+        self.assertEqual(app.other_button.state, "disabled")
+
+    def test_enable_settings_widgets_restores_states_and_runs_followup_sync(self):
+        app = self.build_app()
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            app.disable_settings_widgets()
+            app.enable_settings_widgets()
+
+        self.assertEqual(app.watch_folder_entry.state, "normal")
+        self.assertEqual(app.watch_folder_browse_button.state, "normal")
+        self.assertEqual(app.watch_folder_open_button.state, "normal")
+        self.assertEqual(app.create_doc_button.state, "normal")
+        self.assertEqual(app.docs_input_entry.state, "normal")
+        self.assertEqual(app.other_button.state, "normal")
+        app.update_windows_startup_ui_state.assert_called_once()
+
+
+class MainGuiDocsTargetTests(MainGuiTestBase):
+    def test_apply_config_data_keeps_saved_document_editable(self):
+        app = self.build_app()
+        config_data = {
+            "watch_folder": "C:/watch",
+            "docs_input": "https://docs.google.com/document/d/EXAMPLE_ID/edit",
+            "appearance_mode": "Light",
+        }
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            app.apply_config_data(config_data)
+
+        self.assertFalse(app.docs_target_locked.get())
+        self.assertEqual(app.docs_input_entry.state, "normal")
+        self.assertEqual(app.create_doc_button.state, "normal")
+        self.assertEqual(app.manual_doc_input_button.state, "normal")
+        self.assertEqual(app.select_doc_button.state, "normal")
+        self.assertEqual(
+            app.docs_target_status_var.get(),
+            "문서가 입력되어 있습니다. 감시 시작 시 이 문서를 자동으로 확정합니다.",
+        )
+        self.fake_ctk.set_appearance_mode.assert_called_once_with("Light")
+
+    def test_validate_inputs_accepts_editable_document_without_manual_lock(self):
+        app = self.build_app()
+        app.watch_folder.set("C:/watch")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.parse_max_cache_size = Mock(return_value=10000)
+
+        with patch.object(main_gui.os.path, "exists", return_value=True), patch.object(
+            main_gui.os.path,
+            "isdir",
+            return_value=True,
+        ):
+            errors = app.validate_inputs()
+
+        self.assertEqual(errors, [])
+
+    def test_lock_and_focus_existing_docs_input_restore_editable_state(self):
+        app = self.build_app()
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            self.assertTrue(app.lock_docs_target(source_label="직접 입력"))
+            self.assertTrue(app.docs_target_locked.get())
+            self.assertEqual(app.docs_input_entry.state, "disabled")
+            self.assertEqual(app.create_doc_button.state, "disabled")
+            self.assertEqual(app.manual_doc_input_button.state, "disabled")
+            self.assertEqual(app.select_doc_button.state, "disabled")
+
+            app.focus_existing_docs_input()
+
+        self.assertFalse(app.docs_target_locked.get())
+        self.assertEqual(app.docs_input_entry.state, "normal")
+        self.assertEqual(app.create_doc_button.state, "normal")
+        self.assertEqual(app.manual_doc_input_button.state, "normal")
+        self.assertEqual(app.select_doc_button.state, "normal")
+        self.assertTrue(app.docs_input_entry.focused)
+        self.assertEqual(app.docs_input_entry.cursor_position, "end")
+        app.log.assert_any_call("대상 문서 경로 고정됨: 직접 입력")
+        app.log.assert_any_call("기존 Google Docs 주소/ID 직접 입력 모드.")
+
+    def test_on_monitoring_stopped_unlocks_document_controls(self):
+        app = self.build_app()
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.docs_target_locked.set(True)
+        app.is_monitoring = True
+        app.monitoring_thread = object()
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            app.refresh_docs_target_ui()
+            app.on_monitoring_stopped()
+
+        self.assertFalse(app.docs_target_locked.get())
+        self.assertFalse(app.is_monitoring)
+        self.assertIsNone(app.monitoring_thread)
+        self.assertEqual(app.start_button.state, "normal")
+        self.assertEqual(app.stop_button.state, "disabled")
+        self.assertEqual(app.docs_input_entry.state, "normal")
+        self.assertEqual(app.create_doc_button.state, "normal")
+        self.assertEqual(app.manual_doc_input_button.state, "normal")
+        self.assertEqual(app.select_doc_button.state, "normal")
+        self.assertEqual(app.watch_folder_open_button.state, "normal")
+        app.update_status.assert_called_once_with("준비")
+        app.update_windows_startup_ui_state.assert_called_once()
+        app.log.assert_any_call("감시 중지로 대상 문서 고정이 해제되었습니다.")
+        app.log.assert_any_call("감시 중지됨.")
+
+    def test_start_monitoring_auto_locks_document_before_background_run(self):
+        app = self.build_app()
+        app.watch_folder.set("C:/watch")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.settings_changed = False
+        app.stop_event = Mock()
+        app.parse_max_cache_size = Mock(return_value=10000)
+        app.verify_google_services_before_monitoring = Mock(return_value={"docs": object()})
+        app.log_threadsafe = Mock()
+        app.extracted_result_threadsafe = Mock()
+        app.disable_settings_widgets = Mock()
+        fake_thread = Mock()
+
+        with patch.object(main_gui, "ctk", self.fake_ctk), patch.object(
+            main_gui,
+            "run_monitoring",
+            Mock(),
+        ), patch.object(main_gui.os.path, "exists", return_value=True), patch.object(
+            main_gui.os.path,
+            "isdir",
+            return_value=True,
+        ), patch.object(main_gui.threading, "Thread", return_value=fake_thread):
+            app.start_monitoring()
+
+        self.assertTrue(app.docs_target_locked.get())
+        self.assertEqual(app.docs_input_entry.state, "disabled")
+        self.assertEqual(app.create_doc_button.state, "disabled")
+        self.assertEqual(app.manual_doc_input_button.state, "disabled")
+        self.assertEqual(app.select_doc_button.state, "disabled")
+        self.assertEqual(app.start_button.state, "disabled")
+        self.assertEqual(app.stop_button.state, "normal")
+        app.verify_google_services_before_monitoring.assert_called_once()
+        app.stop_event.clear.assert_called_once()
+        app.disable_settings_widgets.assert_called_once()
+        fake_thread.start.assert_called_once()
+        app.log.assert_any_call("감시 시작을 위해 대상 문서를 자동으로 확정했습니다.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_window_ui.py
+++ b/tests/test_main_window_ui.py
@@ -73,6 +73,8 @@ class MainWindowUiTests(unittest.TestCase):
         self.assertIn("height=124", self.source)
         self.assertIn("width=480", self.source)
         self.assertIn("문서 ID", self.source)
+        self.assertIn('"watch_folder_browse_button": watch_folder_browse_button', self.source)
+        self.assertIn('"watch_folder_open_button": watch_folder_open_button', self.source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- 감시 중에도 감시 폴더 열기 버튼을 유지하도록 설정 잠금 로직을 정리했습니다.
- 저장된 문서 주소가 있어도 앱 시작 시 문서 작업 영역이 잠기지 않도록 수정했습니다.
- 감시 시작 시 문서를 자동 확정하고, 감시 중지 시 문서 고정을 해제하도록 UX를 개선했습니다.
- 관련 문서 잠금/설정 잠금 회귀 테스트를 추가했습니다.

## 테스트
- pytest -q tests\\test_main_gui_settings_lock.py tests\\test_main_window_ui.py tests\\test_main_gui_docs_actions.py
- python -m py_compile main_gui.py