### PR TITLE
Add cache folder quick access in settings

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -58,6 +58,7 @@ except ImportError:
 try:
     from src.auto_write_txt_to_docs.path_utils import (
         BUNDLED_CREDENTIALS_FILE_STR,
+        CACHE_FILE_STR,
         CONFIG_FILE_STR,
         USER_CREDENTIALS_FILE_STR,
         LEGACY_CONFIG_FILE_STR,
@@ -67,6 +68,7 @@ try:
 except ImportError:
     logging.error("경로 유틸리티 모듈(path_utils.py)을 찾을 수 없습니다.")
     BUNDLED_CREDENTIALS_FILE_STR = None
+    CACHE_FILE_STR = "added_lines_cache.json"
     CONFIG_FILE_STR = "config.json"
     USER_CREDENTIALS_FILE_STR = "developer_credentials.json"
     LEGACY_CONFIG_FILE_STR = "config.json"
@@ -1245,6 +1247,7 @@ class MessengerDocsApp:
                 "optimize_memory": self.optimize_memory,
                 "browse_folder": self.browse_folder,
                 "open_watch_folder": lambda: self.open_folder_in_explorer(self.watch_folder.get()),
+                "open_cache_folder": lambda: self.open_folder_in_explorer(os.path.dirname(CACHE_FILE_STR)),
                 "show_filter_settings": self.show_filter_settings,
                 "create_new_google_doc": self.create_new_google_doc,
                 "focus_existing_docs_input": self.focus_existing_docs_input,
@@ -2121,6 +2124,7 @@ class MessengerDocsApp:
                 return
             always_enabled_widgets = {
                 getattr(self, "watch_folder_open_button", None),
+                getattr(self, "cache_folder_button", None),
             }
             for child in self.settings_frame.winfo_children():
                 if isinstance(child, ctk.CTkFrame):

--- a/src/auto_write_txt_to_docs/main_window_ui.py
+++ b/src/auto_write_txt_to_docs/main_window_ui.py
@@ -19,6 +19,61 @@ def _font(ctk, size, weight="normal", family=None):
     return ctk.CTkFont(**font_kwargs)
 
 
+def _attach_tooltip(widget, text, delay_ms=450, wraplength=280):
+    """위젯에 마우스 오버 툴팁을 연결한다."""
+    import tkinter as tk
+
+    tooltip_window = None
+    scheduled_job = None
+
+    def hide_tooltip(_event=None):
+        nonlocal tooltip_window, scheduled_job
+        if scheduled_job is not None:
+            widget.after_cancel(scheduled_job)
+            scheduled_job = None
+        if tooltip_window is not None and tooltip_window.winfo_exists():
+            tooltip_window.destroy()
+        tooltip_window = None
+
+    def show_tooltip():
+        nonlocal tooltip_window, scheduled_job
+        scheduled_job = None
+        if tooltip_window is not None or not widget.winfo_exists():
+            return
+
+        tooltip_window = tk.Toplevel(widget)
+        tooltip_window.wm_overrideredirect(True)
+        tooltip_window.attributes("-topmost", True)
+
+        x_pos = widget.winfo_rootx() + widget.winfo_width() + 10
+        y_pos = widget.winfo_rooty() + max(6, widget.winfo_height() // 2)
+        tooltip_window.wm_geometry(f"+{x_pos}+{y_pos}")
+
+        tooltip_label = tk.Label(
+            tooltip_window,
+            text=text,
+            justify="left",
+            background="#111827",
+            foreground="#F9FAFB",
+            relief="solid",
+            borderwidth=1,
+            padx=10,
+            pady=6,
+            wraplength=wraplength,
+        )
+        tooltip_label.pack()
+
+    def schedule_tooltip(_event=None):
+        nonlocal scheduled_job
+        hide_tooltip()
+        scheduled_job = widget.after(delay_ms, show_tooltip)
+
+    widget.bind("<Enter>", schedule_tooltip, add="+")
+    widget.bind("<Leave>", hide_tooltip, add="+")
+    widget.bind("<ButtonPress>", hide_tooltip, add="+")
+    widget.bind("<Destroy>", hide_tooltip, add="+")
+
+
 def _build_status_panel(ctk, parent, state_vars, callbacks, font_family):
     """상단 상태 패널을 생성한다."""
     status_card = ctk.CTkFrame(parent, corner_radius=14)
@@ -254,12 +309,29 @@ def _build_settings_panel(ctk, parent, state_vars, callbacks, font_family):
         validatecommand=validate_command,
     )
     max_cache_size_entry.pack(side="left", padx=4)
+    cache_folder_button = ctk.CTkButton(
+        max_cache_row,
+        text="캐시 폴더 열기",
+        width=112,
+        height=32,
+        corner_radius=10,
+        command=callbacks["open_cache_folder"],
+        font=_font(ctk, 12, "bold", family=font_family),
+        fg_color=("gray85", "gray28"),
+        hover_color=("gray78", "gray34"),
+        text_color=("gray20", "gray92"),
+    )
+    cache_folder_button.pack(side="right")
+    _attach_tooltip(
+        cache_folder_button,
+        "전역 라인 캐시와 처리 상태 파일이 저장된 폴더를 Windows 탐색기에서 엽니다.",
+    )
     ctk.CTkLabel(
         max_cache_row,
         text="중복 비교용 전역 라인 캐시에 유지할 최대 항목 수",
         font=_font(ctk, 12, family=font_family),
         text_color=("gray45", "gray72"),
-    ).pack(side="left", padx=(8, 0))
+    ).pack(side="left", padx=(8, 12))
     notification_row = ctk.CTkFrame(settings_frame, fg_color="transparent")
     notification_row.pack(fill="x", padx=14, pady=4)
     ctk.CTkLabel(
@@ -433,6 +505,7 @@ def _build_settings_panel(ctk, parent, state_vars, callbacks, font_family):
         "watch_folder_open_button": watch_folder_open_button,
         "watch_folder_drop_hint_label": watch_folder_drop_hint_label,
         "max_cache_size_entry": max_cache_size_entry,
+        "cache_folder_button": cache_folder_button,
         "notification_checkbox": notification_checkbox,
         "autostart_checkbox": autostart_checkbox,
         "autostart_hint_label": autostart_hint_label,

--- a/tests/test_main_gui_docs_actions.py
+++ b/tests/test_main_gui_docs_actions.py
@@ -56,6 +56,7 @@ class MainGuiDocsActionsTests(unittest.TestCase):
         self.assertIn("clear_extraction_preview", self.main_gui_source)
         self.assertIn("max_cache_size", self.main_gui_source)
         self.assertIn("parse_max_cache_size", self.main_gui_source)
+        self.assertIn("CACHE_FILE_STR", self.main_gui_source)
         self.assertIn("first_run", self.main_gui_source)
         self.assertIn("launch_on_windows_startup", self.main_gui_source)
         self.assertIn("autostart_hint", self.main_gui_source)
@@ -92,7 +93,9 @@ class MainGuiDocsActionsTests(unittest.TestCase):
         self.assertIn('text="문서 목록"', self.main_window_ui_source)
         self.assertIn('text="문서 경로 확정"', self.main_window_ui_source)
         self.assertIn('text="라인 캐시 크기"', self.main_window_ui_source)
+        self.assertIn('text="캐시 폴더 열기"', self.main_window_ui_source)
         self.assertIn('text="로그 팝업"', self.main_window_ui_source)
+        self.assertIn('"open_cache_folder": lambda: self.open_folder_in_explorer(os.path.dirname(CACHE_FILE_STR))', self.main_gui_source)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_gui_settings_lock.py
+++ b/tests/test_main_gui_settings_lock.py
@@ -104,6 +104,7 @@ class MainGuiTestBase(unittest.TestCase):
         app.watch_folder_entry = FakeEntry()
         app.watch_folder_browse_button = FakeButton("폴더 선택")
         app.watch_folder_open_button = FakeButton("열기")
+        app.cache_folder_button = FakeButton("캐시 폴더 열기")
 
         app.create_doc_button = FakeButton("새 문서 만들기")
         app.manual_doc_input_button = FakeButton("기존 문서 주소 입력")
@@ -121,6 +122,8 @@ class MainGuiTestBase(unittest.TestCase):
             app.watch_folder_browse_button,
             app.watch_folder_open_button,
         ]
+        cache_row = FakeFrame()
+        cache_row.children = [app.cache_folder_button]
         docs_action_row = FakeFrame()
         docs_action_row.children = [
             app.create_doc_button,
@@ -131,7 +134,7 @@ class MainGuiTestBase(unittest.TestCase):
         docs_input_row.children = [app.docs_input_entry]
         docs_lock_row = FakeFrame()
         docs_lock_row.children = [app.docs_target_status_label, app.docs_lock_button, other_button]
-        app.settings_frame.children = [folder_row, docs_action_row, docs_input_row, docs_lock_row]
+        app.settings_frame.children = [folder_row, cache_row, docs_action_row, docs_input_row, docs_lock_row]
         app.other_button = other_button
         return app
 
@@ -146,6 +149,7 @@ class MainGuiSettingsLockTests(MainGuiTestBase):
         self.assertEqual(app.watch_folder_entry.state, "disabled")
         self.assertEqual(app.watch_folder_browse_button.state, "disabled")
         self.assertEqual(app.watch_folder_open_button.state, "normal")
+        self.assertEqual(app.cache_folder_button.state, "normal")
         self.assertEqual(app.create_doc_button.state, "disabled")
         self.assertEqual(app.docs_input_entry.state, "disabled")
         self.assertEqual(app.other_button.state, "disabled")
@@ -160,6 +164,7 @@ class MainGuiSettingsLockTests(MainGuiTestBase):
         self.assertEqual(app.watch_folder_entry.state, "normal")
         self.assertEqual(app.watch_folder_browse_button.state, "normal")
         self.assertEqual(app.watch_folder_open_button.state, "normal")
+        self.assertEqual(app.cache_folder_button.state, "normal")
         self.assertEqual(app.create_doc_button.state, "normal")
         self.assertEqual(app.docs_input_entry.state, "normal")
         self.assertEqual(app.other_button.state, "normal")

--- a/tests/test_main_window_ui.py
+++ b/tests/test_main_window_ui.py
@@ -13,6 +13,7 @@ class MainWindowUiTests(unittest.TestCase):
         self.assertIn("_build_control_panel", self.source)
         self.assertIn("_build_result_panel", self.source)
         self.assertIn("_build_log_panel", self.source)
+        self.assertIn("def _attach_tooltip", self.source)
 
     def test_main_window_ui_keeps_font_helper_and_workspace_copy(self):
         self.assertIn("def _font", self.source)
@@ -38,6 +39,7 @@ class MainWindowUiTests(unittest.TestCase):
         self.assertIn("작업 설정", self.source)
         self.assertIn("watch_folder_drop_hint", self.source)
         self.assertIn("라인 캐시 크기", self.source)
+        self.assertIn("캐시 폴더 열기", self.source)
         self.assertIn("작업 결과 알림", self.source)
         self.assertIn("작업 결과 효과음", self.source)
         self.assertIn("Windows 자동 실행", self.source)
@@ -61,6 +63,7 @@ class MainWindowUiTests(unittest.TestCase):
         self.assertIn('text="감시 중지"', self.source)
         self.assertIn('text="Docs 웹에서 열기"', self.source)
         self.assertIn('text="폴더 열기"', self.source)
+        self.assertIn('text="캐시 폴더 열기"', self.source)
         self.assertIn('text="검색"', self.source)
         self.assertIn('text="지우기"', self.source)
         self.assertIn("watch_folder_entry", self.source)
@@ -75,6 +78,9 @@ class MainWindowUiTests(unittest.TestCase):
         self.assertIn("문서 ID", self.source)
         self.assertIn('"watch_folder_browse_button": watch_folder_browse_button', self.source)
         self.assertIn('"watch_folder_open_button": watch_folder_open_button', self.source)
+        self.assertIn('"cache_folder_button": cache_folder_button', self.source)
+        self.assertIn('_attach_tooltip(', self.source)
+        self.assertIn("전역 라인 캐시와 처리 상태 파일이 저장된 폴더를 Windows 탐색기에서 엽니다.", self.source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- 설정의 라인 캐시 크기 영역에 `캐시 폴더 열기` 보조 버튼 추가
- 버튼에 전역 라인 캐시/처리 상태 폴더 설명 툴팁 추가
- 관련 UI 및 설정 잠금 동작 테스트 보강

## 테스트
- `python -m pytest tests/test_main_window_ui.py tests/test_main_gui_docs_actions.py tests/test_main_gui_settings_lock.py`