### PR TITLE
Fix release pipeline import fallback encoding issue

### DIFF
--- a/src/auto_write_txt_to_docs/backend_processor.py
+++ b/src/auto_write_txt_to_docs/backend_processor.py
@@ -18,7 +18,7 @@ from datetime import datetime # Docs 헤더에 타임스탬프 사용 위해 유
 try:
     from .google_auth import GoogleAuthActionRequired, get_google_services
 except ImportError:
-    print("오류: google_auth.py 모듈을 찾을 수 없습니다. Google API 인증 기능이 작동하지 않습니다.")
+    logging.error("ERROR: google_auth.py module is missing. Google API authentication is disabled.")
     GoogleAuthActionRequired = Exception
     get_google_services = None
 

--- a/src/auto_write_txt_to_docs/google_auth.py
+++ b/src/auto_write_txt_to_docs/google_auth.py
@@ -25,7 +25,7 @@ except ImportError:
             get_effective_credentials_path,
         )
     except ImportError:
-        print("오류: path_utils.py 파일을 찾을 수 없습니다. Google 인증이 작동하지 않습니다.")
+        logging.error("ERROR: path_utils.py module is missing. Google authentication is disabled.")
         BUNDLED_CREDENTIALS_FILE_STR = None
         USER_CREDENTIALS_FILE_STR = None
         TOKEN_FILE_STR = "token.json"


### PR DESCRIPTION
Release workflow unittest discover failed on Windows cp1252 due to Korean print in import fallback. Replaced two fallback prints with logging.error ASCII messages and verified unittest discover + pytest.