### PR TITLE
feat: 문서 대상 잠금과 검증 UX 강화

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -15,6 +15,7 @@ import logging
 import webbrowser
 from datetime import datetime
 from collections import deque
+from urllib.parse import urlparse
 import psutil  # 메모리 사용량 모니터링용
 import shutil
 from pathlib import Path
@@ -171,13 +172,62 @@ FAILURE_NOTIFICATION_DEBOUNCE_SECONDS = 2.0
 RECENT_RESULT_CARD_LIMIT = 3
 ACTIVITY_RESULT_TAB = "최근 추출 결과"
 ACTIVITY_LOG_TAB = "작업 로그"
+GOOGLE_DOC_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{20,}$")
 
 # --- Helper Function: URL에서 ID 추출 ---
 def extract_google_id_from_url(url_or_id):
-    """ Google Docs URL에서 ID 추출 """
-    if not url_or_id or not isinstance(url_or_id, str): return url_or_id
-    match_docs = re.search(r'/document/d/([a-zA-Z0-9-_]+)', url_or_id)
-    return match_docs.group(1) if match_docs else url_or_id
+    """엄격한 규칙으로 Google Docs URL 또는 문서 ID를 파싱한다."""
+    if not url_or_id or not isinstance(url_or_id, str):
+        return None
+
+    candidate = url_or_id.strip()
+    if not candidate:
+        return None
+
+    if GOOGLE_DOC_ID_PATTERN.fullmatch(candidate):
+        return candidate
+
+    normalized_candidate = candidate
+    if "://" not in normalized_candidate and normalized_candidate.lower().startswith("docs.google.com/"):
+        normalized_candidate = f"https://{normalized_candidate}"
+
+    try:
+        parsed = urlparse(normalized_candidate)
+    except ValueError:
+        return None
+
+    if parsed.scheme and parsed.scheme not in ("http", "https"):
+        return None
+
+    if parsed.netloc.lower() not in {"docs.google.com", "www.docs.google.com"}:
+        return None
+
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) < 3 or path_parts[0] != "document" or path_parts[1] != "d":
+        return None
+
+    docs_id = path_parts[2].strip()
+    if not GOOGLE_DOC_ID_PATTERN.fullmatch(docs_id):
+        return None
+
+    return docs_id
+
+
+def validate_regex_pattern_input(use_regex_filter, regex_pattern):
+    """정규식 필터 설정의 유효성을 검사하고 오류 메시지를 반환한다."""
+    if not use_regex_filter:
+        return None
+
+    normalized_pattern = (regex_pattern or "").strip()
+    if not normalized_pattern:
+        return "정규식 필터를 사용할 때는 패턴을 입력해주세요."
+
+    try:
+        re.compile(normalized_pattern)
+    except re.error as error:
+        return f"정규식 패턴이 올바르지 않습니다: {error}"
+
+    return None
 
 
 def format_google_modified_time(modified_time_text):
@@ -434,6 +484,8 @@ class MessengerDocsApp:
         self.autostart_hint = ctk.StringVar(value="Windows 로그인 시 이 앱을 자동으로 실행합니다. 스위치를 바꾸면 시작프로그램 등록 상태가 바로 반영됩니다.")
         self.update_check_status = ctk.StringVar(value=self.get_default_update_check_status())
         self.docs_input = ctk.StringVar()
+        self.docs_target_user_locked = tk.BooleanVar(value=False)
+        self.docs_target_runtime_locked = tk.BooleanVar(value=False)
         self.docs_target_locked = tk.BooleanVar(value=False)
         self.docs_target_status_var = ctk.StringVar(value="문서를 지정하면 여기서 고정 상태를 확인할 수 있습니다.")
         self.readiness_var = ctk.StringVar(value="준비도 확인 중...")
@@ -917,8 +969,11 @@ class MessengerDocsApp:
             docs_input = self.docs_input.get().strip()
             if docs_input:
                 docs_id = extract_google_id_from_url(docs_input)
-                docs_id_display = docs_id[:10] + "..." if len(docs_id) > 12 else docs_id
-                self.docs_info_var.set(f"문서: {docs_id_display}")
+                if docs_id:
+                    docs_id_display = docs_id[:10] + "..." if len(docs_id) > 12 else docs_id
+                    self.docs_info_var.set(f"문서: {docs_id_display}")
+                else:
+                    self.docs_info_var.set("문서: 형식 확인 필요")
             else:
                 self.docs_info_var.set("문서: 설정되지 않음")
 
@@ -948,6 +1003,7 @@ class MessengerDocsApp:
         """로컬에서 즉시 판별 가능한 준비 상태를 계산한다."""
         watch_folder = self.watch_folder.get().strip()
         docs_input_val = self.docs_input.get().strip()
+        regex_error = validate_regex_pattern_input(self.use_regex_filter.get(), self.regex_pattern.get())
 
         if not watch_folder:
             return {
@@ -966,6 +1022,12 @@ class MessengerDocsApp:
                 "ready": False,
                 "message": "준비 필요: Google Docs URL 또는 ID를 확인하세요.",
                 "advanced_invalid": False,
+            }
+        if regex_error:
+            return {
+                "ready": False,
+                "message": f"준비 필요: {regex_error}",
+                "advanced_invalid": True,
             }
 
         try:
@@ -1240,18 +1302,47 @@ class MessengerDocsApp:
     def refresh_docs_target_ui(self):
         """문서 대상 고정 상태에 따라 입력/선택 UI를 갱신한다."""
         docs_input_val = self.docs_input.get().strip()
-        locked = bool(self.docs_target_locked.get())
-        if locked and not docs_input_val:
-            locked = False
-            self.docs_target_locked.set(locked)
+        docs_id = extract_google_id_from_url(docs_input_val)
+        if not docs_id:
+            self.set_docs_target_user_locked(False)
+            self.set_docs_target_runtime_locked(False)
 
-        if locked:
-            status_text = "대상 문서가 고정되었습니다. 감시 시작 시 이 문서로 기록합니다."
+        user_locked = self.is_docs_target_user_locked()
+        runtime_locked = self.is_docs_target_runtime_locked()
+        locked = self.sync_docs_target_lock_state()
+
+        if user_locked and runtime_locked:
+            status_text = "대상 문서가 고정되었습니다. 감시 중에는 보호 잠금이 적용되고, 종료 후에는 수동 고정만 유지됩니다."
             status_color = ("#0F9D58", "#81C995")
             lock_button_text = "문서 경로 변경"
             lock_button_color = ("gray85", "gray28")
             lock_button_hover = ("gray78", "gray34")
             lock_button_text_color = ("gray20", "gray92")
+            lock_button_state = "normal"
+        elif user_locked:
+            status_text = "대상 문서가 수동으로 고정되었습니다. 감시를 멈춰도 이 고정은 유지됩니다."
+            status_color = ("#0F9D58", "#81C995")
+            lock_button_text = "문서 경로 변경"
+            lock_button_color = ("gray85", "gray28")
+            lock_button_hover = ("gray78", "gray34")
+            lock_button_text_color = ("gray20", "gray92")
+            lock_button_state = "normal"
+        elif runtime_locked:
+            status_text = "감시 중 대상 문서가 자동으로 잠겨 있습니다. 감시가 끝나면 자동 잠금만 해제됩니다."
+            status_color = ("#0F9D58", "#81C995")
+            lock_button_text = "문서 경로 변경"
+            lock_button_color = ("gray85", "gray28")
+            lock_button_hover = ("gray78", "gray34")
+            lock_button_text_color = ("gray20", "gray92")
+            lock_button_state = "normal"
+        elif docs_input_val and not docs_id:
+            status_text = "문서 형식을 확인하세요. 올바른 Google Docs URL 또는 ID만 사용할 수 있습니다."
+            status_color = ("#B42318", "#FDA29B")
+            lock_button_text = "문서 형식 오류"
+            lock_button_color = ("gray85", "gray28")
+            lock_button_hover = ("gray78", "gray34")
+            lock_button_text_color = ("gray20", "gray92")
+            lock_button_state = "disabled"
         elif docs_input_val:
             status_text = "문서가 입력되어 있습니다. 감시 시작 시 이 문서를 자동으로 확정합니다."
             status_color = ("#1A73E8", "#8AB4F8")
@@ -1259,6 +1350,7 @@ class MessengerDocsApp:
             lock_button_color = "#1A73E8"
             lock_button_hover = "#1765CC"
             lock_button_text_color = None
+            lock_button_state = "normal"
         else:
             status_text = "문서를 지정하면 여기서 고정 상태를 확인할 수 있습니다."
             status_color = ("gray40", "gray70")
@@ -1266,6 +1358,7 @@ class MessengerDocsApp:
             lock_button_color = "#1A73E8"
             lock_button_hover = "#1765CC"
             lock_button_text_color = None
+            lock_button_state = "disabled"
 
         self.docs_target_status_var.set(status_text)
 
@@ -1277,6 +1370,7 @@ class MessengerDocsApp:
                 "text": lock_button_text,
                 "fg_color": lock_button_color,
                 "hover_color": lock_button_hover,
+                "state": lock_button_state,
             }
             if lock_button_text_color is not None:
                 configure_kwargs["text_color"] = lock_button_text_color
@@ -1293,22 +1387,65 @@ class MessengerDocsApp:
             if hasattr(self, widget_name):
                 getattr(self, widget_name).configure(state=selection_state)
 
+    def is_docs_target_user_locked(self):
+        """사용자 수동 고정 상태를 반환한다."""
+        var = getattr(self, "docs_target_user_locked", None)
+        if hasattr(var, "get"):
+            return bool(var.get())
+        legacy_var = getattr(self, "docs_target_locked", None)
+        return bool(legacy_var.get()) if hasattr(legacy_var, "get") else False
+
+    def is_docs_target_runtime_locked(self):
+        """감시 중 자동 잠금 상태를 반환한다."""
+        var = getattr(self, "docs_target_runtime_locked", None)
+        return bool(var.get()) if hasattr(var, "get") else False
+
+    def sync_docs_target_lock_state(self):
+        """분리된 잠금 상태를 합쳐 UI용 파생 상태를 동기화한다."""
+        locked = self.is_docs_target_user_locked() or self.is_docs_target_runtime_locked()
+        legacy_var = getattr(self, "docs_target_locked", None)
+        if hasattr(legacy_var, "set"):
+            legacy_var.set(locked)
+        return locked
+
+    def set_docs_target_user_locked(self, locked):
+        """수동 고정 상태를 갱신한다."""
+        var = getattr(self, "docs_target_user_locked", None)
+        if hasattr(var, "set"):
+            var.set(bool(locked))
+        self.sync_docs_target_lock_state()
+
+    def set_docs_target_runtime_locked(self, locked):
+        """감시 중 자동 잠금 상태를 갱신한다."""
+        var = getattr(self, "docs_target_runtime_locked", None)
+        if hasattr(var, "set"):
+            var.set(bool(locked))
+        self.sync_docs_target_lock_state()
+
     def lock_docs_target(self, source_label="직접 입력"):
         """현재 입력된 문서를 대상 문서로 고정한다."""
         docs_input_val = self.docs_input.get().strip()
         if not docs_input_val:
             messagebox.showwarning("문서 경로 미지정", "먼저 문서 주소 또는 문서 ID를 입력해주세요.", parent=self.root)
             return False
+        if not extract_google_id_from_url(docs_input_val):
+            messagebox.showwarning(
+                "문서 형식 오류",
+                "올바른 Google Docs URL 또는 문서 ID를 입력한 뒤 다시 시도해주세요.",
+                parent=self.root,
+            )
+            return False
 
-        self.docs_target_locked.set(True)
+        self.set_docs_target_user_locked(True)
         self.refresh_docs_target_ui()
         self.log(f"대상 문서 경로 고정됨: {source_label}")
         return True
 
     def unlock_docs_target(self, focus_entry=False):
         """대상 문서 고정을 해제하고 수정 모드로 전환한다."""
-        was_locked = self.docs_target_locked.get()
-        self.docs_target_locked.set(False)
+        was_locked = self.sync_docs_target_lock_state()
+        self.set_docs_target_user_locked(False)
+        self.set_docs_target_runtime_locked(False)
         self.refresh_docs_target_ui()
         if was_locked:
             self.log("대상 문서 경로 고정 해제됨. 문서 변경 가능.")
@@ -1321,7 +1458,7 @@ class MessengerDocsApp:
 
     def toggle_docs_target_lock(self):
         """대상 문서 경로의 고정/수정 상태를 전환한다."""
-        if self.docs_target_locked.get():
+        if self.sync_docs_target_lock_state():
             self.unlock_docs_target(focus_entry=True)
             return
 
@@ -1378,6 +1515,10 @@ class MessengerDocsApp:
             docs_id = extract_google_id_from_url(docs_input_val)
             if not docs_id:
                 errors.append("유효한 Google Docs URL 또는 ID를 입력해주세요.")
+
+        regex_error = validate_regex_pattern_input(self.use_regex_filter.get(), self.regex_pattern.get())
+        if regex_error:
+            errors.append(regex_error)
 
         try:
             self.parse_max_cache_size()
@@ -1447,6 +1588,92 @@ class MessengerDocsApp:
             self.log(f"오류: Google Docs 문서 열기 실패 - {e}")
             messagebox.showerror("오류", f"Google Docs 문서 열기 실패:\n{e}", parent=self.root)
 
+    def build_filter_settings_snapshot(self):
+        """현재 필터 설정 상태를 편집 가능한 스냅샷으로 반환한다."""
+        return {
+            "file_extensions": self.file_extensions.get(),
+            "use_regex_filter": self.use_regex_filter.get(),
+            "regex_pattern": self.regex_pattern.get(),
+        }
+
+    def apply_filter_settings_snapshot(self, snapshot):
+        """필터 설정 스냅샷을 실제 UI 상태에 반영한다."""
+        self.file_extensions.set(snapshot.get("file_extensions", ""))
+        self.use_regex_filter.set(bool(snapshot.get("use_regex_filter", False)))
+        self.regex_pattern.set(snapshot.get("regex_pattern", ""))
+        self.on_setting_changed()
+
+    def validate_current_regex_filter(self):
+        """현재 필터 설정의 정규식 유효성을 검사한다."""
+        return validate_regex_pattern_input(self.use_regex_filter.get(), self.regex_pattern.get())
+
+    def validate_filter_settings_snapshot(self, snapshot):
+        """필터 설정 스냅샷의 정규식 유효성을 검사한다."""
+        return validate_regex_pattern_input(
+            bool(snapshot.get("use_regex_filter", False)),
+            snapshot.get("regex_pattern", ""),
+        )
+
+    def normalize_filter_settings_snapshot(self, snapshot):
+        """필터 설정 스냅샷을 저장 가능한 값으로 정규화한다."""
+        return {
+            "file_extensions": (snapshot.get("file_extensions", "") or "").strip(),
+            "use_regex_filter": bool(snapshot.get("use_regex_filter", False)),
+            "regex_pattern": (snapshot.get("regex_pattern", "") or "").strip(),
+        }
+
+    def evaluate_filter_settings_snapshot(self, snapshot, filename):
+        """필터 스냅샷이 파일명에 매칭되는지 검사하고 결과 문구를 반환한다."""
+        normalized_filename = (filename or "").strip()
+        if not normalized_filename:
+            return {"error": None, "message": "파일 이름을 입력하세요", "matches": False}
+
+        normalized_snapshot = self.normalize_filter_settings_snapshot(snapshot)
+        regex_error = self.validate_filter_settings_snapshot(normalized_snapshot)
+        if regex_error:
+            return {"error": regex_error, "message": "정규식 패턴 오류", "matches": False}
+
+        extensions = [ext.strip() for ext in normalized_snapshot["file_extensions"].split(",") if ext.strip()]
+        ext_match = any(normalized_filename.lower().endswith(ext.lower()) for ext in extensions) if extensions else True
+
+        regex_match = True
+        if normalized_snapshot["use_regex_filter"] and normalized_snapshot["regex_pattern"]:
+            pattern = re.compile(normalized_snapshot["regex_pattern"])
+            regex_match = bool(pattern.search(normalized_filename))
+
+        matches = ext_match and regex_match
+        return {
+            "error": None,
+            "message": "매칭됨: 이 파일은 감시 대상입니다" if matches else "매칭 안됨: 이 파일은 무시됩니다",
+            "matches": matches,
+        }
+
+    def apply_filter_settings_snapshot_if_valid(
+        self,
+        snapshot,
+        *,
+        filter_error_var=None,
+        test_result_var=None,
+        close_callback=None,
+    ):
+        """유효한 경우에만 필터 설정 스냅샷을 적용한다."""
+        normalized_snapshot = self.normalize_filter_settings_snapshot(snapshot)
+        regex_error = self.validate_filter_settings_snapshot(normalized_snapshot)
+        if regex_error:
+            if filter_error_var is not None:
+                filter_error_var.set(regex_error)
+            if test_result_var is not None:
+                test_result_var.set("정규식 패턴 오류")
+            return False
+
+        if filter_error_var is not None:
+            filter_error_var.set("")
+        self.apply_filter_settings_snapshot(normalized_snapshot)
+        self.log("고급 파일 필터 설정 적용됨.")
+        if close_callback:
+            close_callback()
+        return True
+
     def focus_existing_docs_input(self):
         """기존 Google Docs URL/ID를 직접 입력할 수 있도록 입력칸에 포커스를 준다."""
         self.unlock_docs_target(focus_entry=True)
@@ -1473,6 +1700,22 @@ class MessengerDocsApp:
 
     def begin_google_service_request(self, purpose, require_drive, on_success):
         """비대화형 확인 후 필요 시 foreground 재인증으로 이어지는 공통 진입점."""
+        self.begin_google_service_request_with_options(
+            purpose=purpose,
+            require_drive=require_drive,
+            on_success=on_success,
+        )
+
+    def begin_google_service_request_with_options(
+        self,
+        *,
+        purpose,
+        require_drive,
+        on_success,
+        force_interactive=False,
+        quarantine_before_interactive=False,
+    ):
+        """Google 서비스 준비 흐름을 옵션과 함께 시작한다."""
         if not get_google_services:
             self.log("오류: Google 인증 모듈을 불러오지 못했습니다.")
             if hasattr(self, "google_connection_status_var"):
@@ -1486,16 +1729,24 @@ class MessengerDocsApp:
             messagebox.showinfo("Google 연결 진행 중", "이미 Google 연결 또는 재인증 작업이 진행 중입니다.", parent=self.root)
             return
 
+        if force_interactive and quarantine_before_interactive and quarantine_token_file:
+            quarantined_path = quarantine_token_file(self.log, reason_code="manual_reauth")
+            if quarantined_path:
+                self.log(f"수동 재연결을 위해 기존 토큰을 격리했습니다: {quarantined_path}")
+
         self.google_auth_operation_in_progress = True
         if hasattr(self, "google_connection_status_var"):
-            self.google_connection_status_var.set("연결 확인 중")
-        self.update_status("Google 연결 확인 중...", self.describe_google_request_purpose(purpose))
+            self.google_connection_status_var.set("브라우저에서 승인 대기 중" if force_interactive else "연결 확인 중")
+        self.update_status(
+            "브라우저에서 승인 대기 중..." if force_interactive else "Google 연결 확인 중...",
+            self.describe_google_request_purpose(purpose),
+        )
         self.update_monitoring_action_ui()
         self._start_google_service_worker(
             purpose=purpose,
             require_drive=require_drive,
             on_success=on_success,
-            interactive=False,
+            interactive=force_interactive,
         )
 
     def _start_google_service_worker(self, purpose, require_drive, on_success, interactive):
@@ -1662,10 +1913,12 @@ class MessengerDocsApp:
             messagebox.showerror("모듈 오류", "Google 재인증 기능을 불러오지 못했습니다.", parent=self.root)
             return
 
-        self.begin_google_service_request(
+        self.begin_google_service_request_with_options(
             purpose="manual_reauth",
             require_drive=False,
             on_success=self._finish_manual_google_reauthentication,
+            force_interactive=True,
+            quarantine_before_interactive=True,
         )
 
     def _finish_manual_google_reauthentication(self, services):
@@ -2809,6 +3062,14 @@ class MessengerDocsApp:
             if hasattr(self, 'root') and self.root.winfo_exists():
                 self.root.after(100, self.process_result_queue)
     def save_config(self):
+        regex_error = self.validate_current_regex_filter()
+        if regex_error:
+            self.advanced_settings_expanded = True
+            self.update_readiness_ui()
+            self.update_status("준비", "정규식 오류")
+            messagebox.showerror("저장 오류", regex_error, parent=self.root)
+            return
+
         if not save_app_config:
             messagebox.showerror("저장 오류", "설정 저장 모듈을 불러오지 못했습니다.", parent=self.root)
             return
@@ -2851,7 +3112,8 @@ class MessengerDocsApp:
         self.check_updates_on_startup.set(normalized_config.get("check_updates_on_startup", True))
         self.watch_folder.set(normalized_config.get("watch_folder", ""))
         self.docs_input.set(normalized_config.get("docs_input", ""))
-        self.docs_target_locked.set(False)
+        self.set_docs_target_user_locked(False)
+        self.set_docs_target_runtime_locked(False)
         self.show_help_on_startup.set(normalized_config.get("show_help_on_startup", True))
         self.show_success_notifications.set(normalized_config.get("show_success_notifications", True))
         self.play_event_sounds.set(normalized_config.get("play_event_sounds", True))
@@ -2935,14 +3197,25 @@ class MessengerDocsApp:
         )
 
     def _start_monitoring_with_services(self, google_services):
-        if not self.docs_target_locked.get():
-            self.docs_target_locked.set(True)
+        had_manual_lock = self.is_docs_target_user_locked()
+        if not self.is_docs_target_runtime_locked():
+            self.set_docs_target_runtime_locked(True)
             self.refresh_docs_target_ui()
-            self.log("감시 시작을 위해 대상 문서를 자동으로 확정했습니다.")
+            if not had_manual_lock:
+                self.log("감시 시작을 위해 대상 문서를 자동으로 확정했습니다.")
         
         watch_folder = self.watch_folder.get().strip()
         docs_input_val = self.docs_input.get().strip()
         docs_id = extract_google_id_from_url(docs_input_val)
+        if not docs_id:
+            self.set_docs_target_runtime_locked(False)
+            self.refresh_docs_target_ui()
+            self.is_monitoring = False
+            self.google_auth_operation_in_progress = False
+            self.update_monitoring_action_ui()
+            self.update_status("준비", "문서 입력 오류")
+            messagebox.showerror("입력 오류", "유효한 Google Docs URL 또는 ID를 확인한 뒤 다시 시도해주세요.", parent=self.root)
+            return
         max_cache_size = self.parse_max_cache_size()
         
         self.log(f"처리할 Docs ID: {docs_id}")
@@ -2997,9 +3270,10 @@ class MessengerDocsApp:
     def on_monitoring_stopped(self):
         self.is_monitoring = False
         self.monitoring_thread = None
-        was_docs_locked = self.docs_target_locked.get() if hasattr(self, "docs_target_locked") else False
-        if was_docs_locked:
-            self.docs_target_locked.set(False)
+        was_runtime_locked = self.is_docs_target_runtime_locked()
+        was_user_locked = self.is_docs_target_user_locked()
+        if was_runtime_locked:
+            self.set_docs_target_runtime_locked(False)
         if hasattr(self, 'root') and self.root.winfo_exists():
             try:
                 self.enable_settings_widgets()
@@ -3008,8 +3282,10 @@ class MessengerDocsApp:
                 self.current_processing_filename = None
                 self.pending_docs_update_line_count = None
                 self.update_runtime_summary_ui()
-                if was_docs_locked:
-                    self.log("감시 중지로 대상 문서 고정이 해제되었습니다.")
+                if was_runtime_locked and was_user_locked:
+                    self.log("감시 중 자동 잠금이 해제되었고 수동 고정은 유지됩니다.")
+                elif was_runtime_locked:
+                    self.log("감시 중 자동 잠금이 해제되었습니다.")
                 self.update_status("준비")
                 self.log("감시 중지됨.")
             except Exception:
@@ -3574,7 +3850,12 @@ class MessengerDocsApp:
         filter_window.minsize(650, 450)
         filter_window.transient(self.root)  # 부모 창 위에 표시
         filter_window.grab_set()  # 모달 창으로 설정
-        
+        filter_settings = self.build_filter_settings_snapshot()
+        temp_file_extensions = ctk.StringVar(value=filter_settings["file_extensions"])
+        temp_use_regex_filter = tk.BooleanVar(value=filter_settings["use_regex_filter"])
+        temp_regex_pattern = ctk.StringVar(value=filter_settings["regex_pattern"])
+        filter_error_var = ctk.StringVar(value="")
+
         # 메인 프레임
         main_frame = ctk.CTkFrame(filter_window)
         main_frame.pack(fill="both", expand=True, padx=20, pady=20)
@@ -3594,7 +3875,7 @@ class MessengerDocsApp:
             text="감시할 파일 확장자를 쉼표로 구분하여 입력하세요.\n예: .txt,.log,.md"
         ).pack(anchor="w", pady=(0, 5))
         
-        ext_entry = ctk.CTkEntry(ext_frame, textvariable=self.file_extensions)
+        ext_entry = ctk.CTkEntry(ext_frame, textvariable=temp_file_extensions)
         ext_entry.pack(fill="x", pady=5)
         
         # 미리 정의된 확장자 선택 버튼들
@@ -3602,14 +3883,14 @@ class MessengerDocsApp:
         preset_frame.pack(fill="x", pady=5)
         
         def add_extension(ext):
-            current = self.file_extensions.get().strip()
+            current = temp_file_extensions.get().strip()
             if not current:
-                self.file_extensions.set(ext)
+                temp_file_extensions.set(ext)
             else:
                 exts = [e.strip() for e in current.split(",")]
                 if ext not in exts:
                     exts.append(ext)
-                    self.file_extensions.set(",".join(exts))
+                    temp_file_extensions.set(",".join(exts))
         
         ctk.CTkButton(
             preset_frame, 
@@ -3655,7 +3936,7 @@ class MessengerDocsApp:
         regex_check = ctk.CTkCheckBox(
             regex_header,
             text="정규식 필터 사용",
-            variable=self.use_regex_filter,
+            variable=temp_use_regex_filter,
             onvalue=True,
             offvalue=False
         )
@@ -3666,8 +3947,15 @@ class MessengerDocsApp:
             text="파일 이름에 적용할 정규식 패턴을 입력하세요.\n예: ^log_\\d{8}\\.txt$ (log_날짜8자리.txt 형식 파일만 매칭)"
         ).pack(anchor="w", pady=(0, 5))
         
-        regex_entry = ctk.CTkEntry(regex_frame, textvariable=self.regex_pattern)
+        regex_entry = ctk.CTkEntry(regex_frame, textvariable=temp_regex_pattern)
         regex_entry.pack(fill="x", pady=5)
+
+        regex_error_label = ctk.CTkLabel(
+            regex_frame,
+            textvariable=filter_error_var,
+            text_color=("#B42318", "#FDA29B"),
+        )
+        regex_error_label.pack(anchor="w", pady=(0, 5))
         
         # 테스트 섹션
         test_frame = ctk.CTkFrame(main_frame)
@@ -3691,31 +3979,30 @@ class MessengerDocsApp:
         test_result_var = ctk.StringVar(value="")
         
         def test_filter():
-            filename = test_filename_var.get().strip()
-            if not filename:
-                test_result_var.set("파일 이름을 입력하세요")
-                return
-                
-            # 확장자 필터 테스트
-            extensions = [ext.strip() for ext in self.file_extensions.get().split(",") if ext.strip()]
-            ext_match = any(filename.lower().endswith(ext.lower()) for ext in extensions) if extensions else True
-            
-            # 정규식 필터 테스트
-            regex_match = True
-            if self.use_regex_filter.get() and self.regex_pattern.get().strip():
-                try:
-                    import re
-                    pattern = re.compile(self.regex_pattern.get())
-                    regex_match = bool(pattern.search(filename))
-                except re.error:
-                    test_result_var.set("정규식 패턴 오류!")
-                    return
-            
-            # 최종 결과
-            if ext_match and regex_match:
-                test_result_var.set("✅ 매칭됨: 이 파일은 감시 대상입니다")
-            else:
-                test_result_var.set("❌ 매칭 안됨: 이 파일은 무시됩니다")
+            filter_error_var.set("")
+            evaluation = self.evaluate_filter_settings_snapshot(
+                {
+                "file_extensions": temp_file_extensions.get(),
+                "use_regex_filter": temp_use_regex_filter.get(),
+                "regex_pattern": temp_regex_pattern.get(),
+                },
+                test_filename_var.get(),
+            )
+            if evaluation["error"]:
+                filter_error_var.set(evaluation["error"])
+            test_result_var.set(evaluation["message"])
+
+        def apply_filter_settings():
+            self.apply_filter_settings_snapshot_if_valid(
+                {
+                "file_extensions": temp_file_extensions.get().strip(),
+                "use_regex_filter": temp_use_regex_filter.get(),
+                "regex_pattern": temp_regex_pattern.get().strip(),
+                },
+                filter_error_var=filter_error_var,
+                test_result_var=test_result_var,
+                close_callback=filter_window.destroy,
+            )
         
         ctk.CTkButton(
             test_input_frame,
@@ -3735,14 +4022,24 @@ class MessengerDocsApp:
         button_frame = ctk.CTkFrame(main_frame, fg_color="transparent")
         button_frame.pack(fill="x", pady=(15, 0))
         
-        # 확인 버튼
-        ok_button = ctk.CTkButton(
+        cancel_button = ctk.CTkButton(
             button_frame,
-            text="확인",
+            text="취소",
             command=filter_window.destroy,
+            width=100,
+            fg_color=("gray85", "gray28"),
+            hover_color=("gray78", "gray34"),
+            text_color=("gray20", "gray92"),
+        )
+        cancel_button.pack(side="right", padx=(0, 8))
+
+        apply_button = ctk.CTkButton(
+            button_frame,
+            text="적용",
+            command=apply_filter_settings,
             width=100
         )
-        ok_button.pack(side="right")
+        apply_button.pack(side="right")
         
         # 창 중앙 배치
         filter_window.update_idletasks()

--- a/tests/test_main_gui_docs_actions.py
+++ b/tests/test_main_gui_docs_actions.py
@@ -1,122 +1,170 @@
+import types
 import unittest
-from pathlib import Path
+from unittest.mock import Mock, patch
+
+import main_gui
+
+
+class FakeVar:
+    def __init__(self, value=None):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class FakeWidget:
+    def __init__(self, text=None, state="normal"):
+        self.config = {"text": text, "state": state}
+        self.focused = False
+        self.cursor_position = None
+
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+    @property
+    def state(self):
+        return self.config.get("state")
+
+    def focus_set(self):
+        self.focused = True
+
+    def icursor(self, position):
+        self.cursor_position = position
+
+
+class FakeButton(FakeWidget):
+    pass
+
+
+class FakeEntry(FakeWidget):
+    pass
+
+
+class FakeLabel(FakeWidget):
+    pass
+
+
+class FakeRoot:
+    def __init__(self):
+        self.after_calls = []
+
+    def after(self, delay, callback):
+        self.after_calls.append((delay, callback))
+        return len(self.after_calls)
+
+    def winfo_exists(self):
+        return True
 
 
 class MainGuiDocsActionsTests(unittest.TestCase):
     def setUp(self):
-        self.main_gui_source = Path("main_gui.py").read_text(encoding="utf-8")
-        self.main_window_ui_source = Path("src/auto_write_txt_to_docs/main_window_ui.py").read_text(encoding="utf-8")
-
-    def test_main_gui_contains_doc_creation_and_selection_actions(self):
-        self.assertIn("def create_new_google_doc", self.main_gui_source)
-        self.assertIn("def select_google_doc", self.main_gui_source)
-        self.assertIn("def verify_google_services_before_monitoring", self.main_gui_source)
-        self.assertIn("def prompt_google_reauthentication", self.main_gui_source)
-        self.assertIn("def reset_google_auth", self.main_gui_source)
-        self.assertIn("def begin_google_service_request", self.main_gui_source)
-        self.assertIn("GoogleAuthActionRequired", self.main_gui_source)
-        self.assertIn("def extract_docs_update_line_count", self.main_gui_source)
-        self.assertIn("def toggle_docs_target_lock", self.main_gui_source)
-        self.assertIn("def lock_docs_target", self.main_gui_source)
-        self.assertIn("def unlock_docs_target", self.main_gui_source)
-        self.assertIn("def detect_ui_font_family", self.main_gui_source)
-        self.assertIn("def build_ui_font", self.main_gui_source)
-        self.assertIn("def present_main_window", self.main_gui_source)
-        self.assertIn("def run_startup_prompts", self.main_gui_source)
-        self.assertIn("def show_first_run_wizard", self.main_gui_source)
-        self.assertIn("DnDCompatibleTk", self.main_gui_source)
-        self.assertIn("supports_windows_startup", self.main_gui_source)
-        self.assertIn("def start_tray_icon", self.main_gui_source)
-        self.assertIn("run_detached", self.main_gui_source)
-        self.assertIn('trace_add("write"', self.main_gui_source)
-        self.assertIn("def extracted_result_threadsafe", self.main_gui_source)
-        self.assertIn("def append_extraction_preview", self.main_gui_source)
-        self.assertIn("def process_result_queue", self.main_gui_source)
-        self.assertIn("def show_log_popup", self.main_gui_source)
-        self.assertIn("def sync_log_popup_content", self.main_gui_source)
-        self.assertIn("def close_log_popup", self.main_gui_source)
-        self.assertIn("def update_tray_status", self.main_gui_source)
-        self.assertIn("def get_tray_state_key", self.main_gui_source)
-        self.assertIn("def build_tray_status_icon", self.main_gui_source)
-        self.assertIn("def build_tray_menu", self.main_gui_source)
-        self.assertIn("def toggle_monitoring_from_tray", self.main_gui_source)
-        self.assertIn("def open_docs_in_browser_from_tray", self.main_gui_source)
-        self.assertIn("def show_log_popup_from_tray", self.main_gui_source)
-        self.assertIn("def setup_watch_folder_drag_and_drop", self.main_gui_source)
-        self.assertIn("def on_watch_folder_drop", self.main_gui_source)
-        self.assertIn("def update_windows_startup_ui_state", self.main_gui_source)
-        self.assertIn("def refresh_windows_startup_setting_from_system", self.main_gui_source)
-        self.assertIn("def sync_windows_startup_setting", self.main_gui_source)
-        self.assertIn("def on_windows_startup_setting_changed", self.main_gui_source)
-        self.assertIn("def persist_windows_startup_preference", self.main_gui_source)
-        self.assertIn("def can_manage_windows_startup", self.main_gui_source)
-        self.assertIn("감시 일시 정지/재개", self.main_gui_source)
-        self.assertIn("Docs 웹에서 열기", self.main_gui_source)
-        self.assertIn("로그 보기", self.main_gui_source)
-        self.assertIn("self.pending_docs_update_line_count", self.main_gui_source)
-        self.assertIn("self.show_success_notifications.get()", self.main_gui_source)
-        self.assertIn("self.tray_icon.notify(message, title)", self.main_gui_source)
-        self.assertIn("create_google_document", self.main_gui_source)
-        self.assertIn("list_accessible_google_documents", self.main_gui_source)
-        self.assertIn("build_main_window_ui", self.main_gui_source)
-        self.assertIn("docs_target_locked", self.main_gui_source)
-        self.assertIn("clear_extraction_preview", self.main_gui_source)
-        self.assertIn("max_cache_size", self.main_gui_source)
-        self.assertIn("parse_max_cache_size", self.main_gui_source)
-        self.assertIn("CACHE_FILE_STR", self.main_gui_source)
-        self.assertIn("first_run", self.main_gui_source)
-        self.assertIn("launch_on_windows_startup", self.main_gui_source)
-        self.assertIn("check_updates_on_startup", self.main_gui_source)
-        self.assertIn("autostart_hint", self.main_gui_source)
-        self.assertIn("self._suppress_autostart_trace = False", self.main_gui_source)
-        self.assertIn("show_success_notifications", self.main_gui_source)
-        self.assertIn("play_event_sounds", self.main_gui_source)
-        self.assertIn("self.show_success_notifications.get()", self.main_gui_source)
-        self.assertIn("self.play_event_sounds.get()", self.main_gui_source)
-        self.assertIn("처음 실행 설정 마법사", self.main_gui_source)
-        self.assertIn("Messenger Docs 시작 마법사", self.main_gui_source)
-        self.assertIn("tkinterdnd2", self.main_gui_source)
-        self.assertIn("Windows 자동 실행", self.main_gui_source)
-        self.assertIn("drop_target_register", self.main_gui_source)
-        self.assertIn("<<Drop>>", self.main_gui_source)
-        self.assertIn("1. 감시 폴더 선택", self.main_gui_source)
-        self.assertIn("2. Google Docs 연결", self.main_gui_source)
-        self.assertIn("3. 알림 및 마무리", self.main_gui_source)
-        self.assertIn("나중에", self.main_gui_source)
-        self.assertIn("Windows 자동 실행: {'켜짐' if self.launch_on_windows_startup.get() else '꺼짐'}", self.main_gui_source)
-        self.assertIn('label="시작 시 새 버전 확인"', self.main_gui_source)
-        self.assertIn('label="새 버전 확인"', self.main_gui_source)
-        self.assertIn("def check_for_updates", self.main_gui_source)
-        self.assertIn('text="스위치를 바꾸면 Windows 시작프로그램 등록 상태가 바로 반영됩니다."', self.main_gui_source)
-        self.assertIn("def configure_log_tags", self.main_gui_source)
-        self.assertIn("def get_log_tag_name", self.main_gui_source)
-        self.assertIn("def append_log_to_widget", self.main_gui_source)
-        self.assertIn("def render_log_lines", self.main_gui_source)
-        self.assertIn('self.root.geometry("980x750")', self.main_gui_source)
-        self.assertIn('self.root.minsize(980, 750)', self.main_gui_source)
-        self.assertIn("⚠️ 기록 불가", self.main_gui_source)
-        self.assertIn("오류 상태", self.main_gui_source)
-        self.assertIn("preloaded_services", self.main_gui_source)
-        self.assertIn("log_success", self.main_gui_source)
-        self.assertIn("log_warning", self.main_gui_source)
-        self.assertIn("log_error", self.main_gui_source)
-        self.assertIn('text="작업 결과 알림 표시"', self.main_window_ui_source)
-        self.assertIn('text="작업 결과 효과음 재생"', self.main_window_ui_source)
-        self.assertIn('text="새 문서 만들기"', self.main_window_ui_source)
-        self.assertIn('text="기존 문서 주소 입력"', self.main_window_ui_source)
-        self.assertIn('text="문서 목록"', self.main_window_ui_source)
-        self.assertIn('text="문서 경로 확정"', self.main_window_ui_source)
-        self.assertIn('text="라인 캐시 크기"', self.main_window_ui_source)
-        self.assertIn('text="캐시 폴더 열기"', self.main_window_ui_source)
-        self.assertIn('text="로그 팝업"', self.main_window_ui_source)
-        self.assertIn('text="Google 계정 다시 연결"', self.main_window_ui_source)
-        self.assertIn('text="인증 초기화"', self.main_window_ui_source)
-        self.assertIn('"open_cache_folder": lambda: self.open_folder_in_explorer(os.path.dirname(CACHE_FILE_STR))', self.main_gui_source)
-        self.assertIn('self.launch_on_windows_startup.trace_add("write", self.on_windows_startup_setting_changed)', self.main_gui_source)
-        self.assertLess(
-            self.main_gui_source.index("self.check_updates_on_startup = tk.BooleanVar(value=True)"),
-            self.main_gui_source.index("self._create_menubar()"),
+        self.fake_ctk = types.SimpleNamespace(
+            CTkFrame=FakeWidget,
+            CTkButton=FakeButton,
+            CTkEntry=FakeEntry,
+            END="end",
         )
+
+    def build_app(self):
+        app = main_gui.MessengerDocsApp.__new__(main_gui.MessengerDocsApp)
+        app.root = FakeRoot()
+        app.docs_input = FakeVar("")
+        app.docs_target_user_locked = FakeVar(False)
+        app.docs_target_runtime_locked = FakeVar(False)
+        app.docs_target_locked = FakeVar(False)
+        app.docs_target_status_var = FakeVar("")
+        app.docs_input_entry = FakeEntry()
+        app.create_doc_button = FakeButton("새 문서 만들기")
+        app.manual_doc_input_button = FakeButton("기존 문서 주소 입력")
+        app.select_doc_button = FakeButton("문서 목록")
+        app.docs_lock_button = FakeButton("문서 경로 확정")
+        app.docs_target_status_label = FakeLabel()
+        app.start_button = FakeButton("감시 시작")
+        app.stop_button = FakeButton("감시 중지", state="disabled")
+        app.log = Mock()
+        app.is_monitoring = False
+        return app
+
+    def test_toggle_docs_target_lock_updates_manual_lock_state(self):
+        app = self.build_app()
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            app.toggle_docs_target_lock()
+
+        self.assertTrue(app.docs_target_user_locked.get())
+        self.assertFalse(app.docs_target_runtime_locked.get())
+        self.assertTrue(app.docs_target_locked.get())
+        self.assertEqual(app.docs_input_entry.state, "disabled")
+
+        with patch.object(main_gui, "ctk", self.fake_ctk):
+            app.toggle_docs_target_lock()
+
+        self.assertFalse(app.docs_target_user_locked.get())
+        self.assertFalse(app.docs_target_runtime_locked.get())
+        self.assertFalse(app.docs_target_locked.get())
+        self.assertEqual(app.docs_input_entry.state, "normal")
+        self.assertTrue(app.docs_input_entry.focused)
+        self.assertEqual(app.docs_input_entry.cursor_position, "end")
+
+    def test_open_docs_in_browser_opens_normalized_url_for_valid_id(self):
+        app = self.build_app()
+        app.docs_input.set("EXAMPLE_DOC_ID_12345")
+
+        with patch.object(main_gui.webbrowser, "open") as open_browser, patch.object(
+            main_gui.messagebox,
+            "showwarning",
+        ) as show_warning:
+            app.open_docs_in_browser()
+
+        open_browser.assert_called_once_with("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+        show_warning.assert_not_called()
+
+    def test_open_docs_in_browser_rejects_invalid_document_url(self):
+        app = self.build_app()
+        app.docs_input.set("https://example.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+
+        with patch.object(main_gui.webbrowser, "open") as open_browser, patch.object(
+            main_gui.messagebox,
+            "showwarning",
+        ) as show_warning:
+            app.open_docs_in_browser()
+
+        open_browser.assert_not_called()
+        show_warning.assert_called_once()
+
+    def test_toggle_monitoring_from_tray_routes_to_start_and_stop(self):
+        app = self.build_app()
+        app.start_monitoring = Mock()
+        app.stop_monitoring = Mock()
+
+        app.toggle_monitoring_from_tray()
+        self.assertEqual(len(app.root.after_calls), 1)
+        _delay, callback = app.root.after_calls.pop()
+        callback()
+        app.start_monitoring.assert_called_once()
+
+        app.is_monitoring = True
+        app.toggle_monitoring_from_tray()
+        self.assertEqual(len(app.root.after_calls), 1)
+        _delay, callback = app.root.after_calls.pop()
+        callback()
+        app.stop_monitoring.assert_called_once()
+
+    def test_open_docs_in_browser_from_tray_schedules_open_action(self):
+        app = self.build_app()
+        app.open_docs_in_browser = Mock()
+
+        app.open_docs_in_browser_from_tray()
+
+        self.assertEqual(len(app.root.after_calls), 1)
+        _delay, callback = app.root.after_calls.pop()
+        callback()
+        app.open_docs_in_browser.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_main_gui_settings_lock.py
+++ b/tests/test_main_gui_settings_lock.py
@@ -117,6 +117,8 @@ class MainGuiTestBase(unittest.TestCase):
         app.watch_folder = FakeVar("")
         app.update_check_status = FakeVar("")
         app.docs_input = FakeVar("")
+        app.docs_target_user_locked = FakeVar(False)
+        app.docs_target_runtime_locked = FakeVar(False)
         app.docs_target_locked = FakeVar(False)
         app.readiness_var = FakeVar("")
         app.google_connection_status_var = FakeVar("")
@@ -227,18 +229,48 @@ class MainGuiSettingsLockTests(MainGuiTestBase):
         app.update_windows_startup_ui_state.assert_called_once()
 
 
+class MainGuiHelperFunctionTests(unittest.TestCase):
+    def test_extract_google_id_from_url_accepts_valid_id_and_docs_url(self):
+        self.assertEqual(
+            main_gui.extract_google_id_from_url("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit"),
+            "EXAMPLE_DOC_ID_12345",
+        )
+        self.assertEqual(
+            main_gui.extract_google_id_from_url("EXAMPLE_DOC_ID_12345"),
+            "EXAMPLE_DOC_ID_12345",
+        )
+
+    def test_extract_google_id_from_url_rejects_invalid_input(self):
+        self.assertIsNone(main_gui.extract_google_id_from_url(""))
+        self.assertIsNone(main_gui.extract_google_id_from_url("https://example.com/document/d/EXAMPLE_DOC_ID_12345/edit"))
+        self.assertIsNone(main_gui.extract_google_id_from_url("not-a-valid-doc-id"))
+
+    def test_validate_regex_pattern_input_rejects_empty_or_invalid_pattern_when_enabled(self):
+        self.assertEqual(
+            main_gui.validate_regex_pattern_input(True, ""),
+            "정규식 필터를 사용할 때는 패턴을 입력해주세요.",
+        )
+        self.assertIn(
+            "정규식 패턴이 올바르지 않습니다",
+            main_gui.validate_regex_pattern_input(True, "[unclosed"),
+        )
+        self.assertIsNone(main_gui.validate_regex_pattern_input(False, "[unclosed"))
+
+
 class MainGuiDocsTargetTests(MainGuiTestBase):
     def test_apply_config_data_keeps_saved_document_editable(self):
         app = self.build_app()
         config_data = {
             "watch_folder": "C:/watch",
-            "docs_input": "https://docs.google.com/document/d/EXAMPLE_ID/edit",
+            "docs_input": "https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit",
             "appearance_mode": "Light",
         }
 
         with patch.object(main_gui, "ctk", self.fake_ctk):
             app.apply_config_data(config_data)
 
+        self.assertFalse(app.docs_target_user_locked.get())
+        self.assertFalse(app.docs_target_runtime_locked.get())
         self.assertFalse(app.docs_target_locked.get())
         self.assertEqual(app.docs_input_entry.state, "normal")
         self.assertEqual(app.create_doc_button.state, "normal")
@@ -253,7 +285,7 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
     def test_validate_inputs_accepts_editable_document_without_manual_lock(self):
         app = self.build_app()
         app.watch_folder.set("C:/watch")
-        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
         app.parse_max_cache_size = Mock(return_value=10000)
 
         with patch.object(main_gui.os.path, "exists", return_value=True), patch.object(
@@ -265,12 +297,64 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
 
         self.assertEqual(errors, [])
 
+    def test_validate_inputs_rejects_invalid_document_url(self):
+        app = self.build_app()
+        app.watch_folder.set("C:/watch")
+        app.docs_input.set("https://example.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+        app.parse_max_cache_size = Mock(return_value=10000)
+
+        with patch.object(main_gui.os.path, "exists", return_value=True), patch.object(
+            main_gui.os.path,
+            "isdir",
+            return_value=True,
+        ):
+            errors = app.validate_inputs()
+
+        self.assertIn("유효한 Google Docs URL 또는 ID를 입력해주세요.", errors)
+
+    def test_validate_inputs_rejects_invalid_regex_pattern(self):
+        app = self.build_app()
+        app.watch_folder.set("C:/watch")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+        app.use_regex_filter.set(True)
+        app.regex_pattern.set("[unclosed")
+        app.parse_max_cache_size = Mock(return_value=10000)
+
+        with patch.object(main_gui.os.path, "exists", return_value=True), patch.object(
+            main_gui.os.path,
+            "isdir",
+            return_value=True,
+        ):
+            errors = app.validate_inputs()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("정규식 패턴이 올바르지 않습니다", errors[0])
+
+    def test_update_readiness_ui_disables_start_button_for_invalid_document_url(self):
+        app = self.build_app()
+        app.watch_folder.set("C:/watch")
+        app.docs_input.set("https://example.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+        app.parse_max_cache_size = Mock(return_value=10000)
+
+        with patch.object(main_gui, "ctk", self.fake_ctk), patch.object(
+            main_gui.os.path,
+            "exists",
+            return_value=True,
+        ), patch.object(main_gui.os.path, "isdir", return_value=True):
+            app.update_readiness_ui()
+
+        self.assertFalse(app.readiness_state["ready"])
+        self.assertEqual(app.start_button.state, "disabled")
+        self.assertIn("Google Docs URL", app.readiness_var.get())
+
     def test_lock_and_focus_existing_docs_input_restore_editable_state(self):
         app = self.build_app()
-        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
 
         with patch.object(main_gui, "ctk", self.fake_ctk):
             self.assertTrue(app.lock_docs_target(source_label="직접 입력"))
+            self.assertTrue(app.docs_target_user_locked.get())
+            self.assertFalse(app.docs_target_runtime_locked.get())
             self.assertTrue(app.docs_target_locked.get())
             self.assertEqual(app.docs_input_entry.state, "disabled")
             self.assertEqual(app.create_doc_button.state, "disabled")
@@ -279,6 +363,8 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
 
             app.focus_existing_docs_input()
 
+        self.assertFalse(app.docs_target_user_locked.get())
+        self.assertFalse(app.docs_target_runtime_locked.get())
         self.assertFalse(app.docs_target_locked.get())
         self.assertEqual(app.docs_input_entry.state, "normal")
         self.assertEqual(app.create_doc_button.state, "normal")
@@ -289,11 +375,23 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
         app.log.assert_any_call("대상 문서 경로 고정됨: 직접 입력")
         app.log.assert_any_call("기존 Google Docs 주소/ID 직접 입력 모드.")
 
-    def test_on_monitoring_stopped_unlocks_document_controls(self):
+    def test_lock_docs_target_rejects_invalid_document_input(self):
+        app = self.build_app()
+        app.docs_input.set("https://example.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+
+        with patch.object(main_gui.messagebox, "showwarning") as show_warning:
+            locked = app.lock_docs_target(source_label="직접 입력")
+
+        self.assertFalse(locked)
+        self.assertFalse(app.docs_target_locked.get())
+        show_warning.assert_called_once()
+
+    def test_on_monitoring_stopped_unlocks_runtime_document_controls(self):
         app = self.build_app()
         app.watch_folder.set("C:/watch")
-        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
-        app.docs_target_locked.set(True)
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+        app.docs_target_runtime_locked.set(True)
+        app.sync_docs_target_lock_state()
         app.is_monitoring = True
         app.monitoring_thread = object()
 
@@ -305,6 +403,8 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
             app.refresh_docs_target_ui()
             app.on_monitoring_stopped()
 
+        self.assertFalse(app.docs_target_user_locked.get())
+        self.assertFalse(app.docs_target_runtime_locked.get())
         self.assertFalse(app.docs_target_locked.get())
         self.assertFalse(app.is_monitoring)
         self.assertIsNone(app.monitoring_thread)
@@ -317,8 +417,35 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
         self.assertEqual(app.watch_folder_open_button.state, "normal")
         app.update_status.assert_called_once_with("준비")
         app.update_windows_startup_ui_state.assert_called_once()
-        app.log.assert_any_call("감시 중지로 대상 문서 고정이 해제되었습니다.")
+        app.log.assert_any_call("감시 중 자동 잠금이 해제되었습니다.")
         app.log.assert_any_call("감시 중지됨.")
+
+    def test_on_monitoring_stopped_keeps_manual_lock_after_runtime_unlock(self):
+        app = self.build_app()
+        app.watch_folder.set("C:/watch")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
+        app.docs_target_user_locked.set(True)
+        app.docs_target_runtime_locked.set(True)
+        app.sync_docs_target_lock_state()
+        app.is_monitoring = True
+        app.monitoring_thread = object()
+
+        with patch.object(main_gui, "ctk", self.fake_ctk), patch.object(
+            main_gui.os.path,
+            "exists",
+            return_value=True,
+        ), patch.object(main_gui.os.path, "isdir", return_value=True):
+            app.refresh_docs_target_ui()
+            app.on_monitoring_stopped()
+
+        self.assertTrue(app.docs_target_user_locked.get())
+        self.assertFalse(app.docs_target_runtime_locked.get())
+        self.assertTrue(app.docs_target_locked.get())
+        self.assertEqual(app.docs_input_entry.state, "disabled")
+        self.assertEqual(app.create_doc_button.state, "disabled")
+        self.assertEqual(app.manual_doc_input_button.state, "disabled")
+        self.assertEqual(app.select_doc_button.state, "disabled")
+        app.log.assert_any_call("감시 중 자동 잠금이 해제되었고 수동 고정은 유지됩니다.")
 
     def test_update_readiness_ui_disables_start_button_until_required_inputs_exist(self):
         app = self.build_app()
@@ -341,7 +468,7 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
     def test_start_monitoring_requests_google_services_before_background_run(self):
         app = self.build_app()
         app.watch_folder.set("C:/watch")
-        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
         app.settings_changed = False
         app.parse_max_cache_size = Mock(return_value=10000)
         app.begin_google_service_request = Mock()
@@ -361,7 +488,7 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
     def test_start_monitoring_with_services_auto_locks_document_before_background_run(self):
         app = self.build_app()
         app.watch_folder.set("C:/watch")
-        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_ID/edit")
+        app.docs_input.set("https://docs.google.com/document/d/EXAMPLE_DOC_ID_12345/edit")
         app.settings_changed = False
         app.stop_event = Mock()
         app.parse_max_cache_size = Mock(return_value=10000)
@@ -381,6 +508,8 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
         ), patch.object(main_gui.threading, "Thread", return_value=fake_thread):
             app._start_monitoring_with_services({"docs": object()})
 
+        self.assertFalse(app.docs_target_user_locked.get())
+        self.assertTrue(app.docs_target_runtime_locked.get())
         self.assertTrue(app.docs_target_locked.get())
         self.assertEqual(app.docs_input_entry.state, "disabled")
         self.assertEqual(app.create_doc_button.state, "disabled")
@@ -433,6 +562,185 @@ class MainGuiDocsTargetTests(MainGuiTestBase):
         self.assertFalse(app.google_auth_operation_in_progress)
         run_interactive_auth_mock.assert_not_called()
         on_success.assert_not_called()
+
+    def test_prompt_google_reauthentication_forces_interactive_browser_flow(self):
+        app = self.build_app()
+        app.begin_google_service_request_with_options = Mock()
+
+        with patch.object(main_gui, "run_interactive_auth", Mock()):
+            app.prompt_google_reauthentication()
+
+        app.begin_google_service_request_with_options.assert_called_once_with(
+            purpose="manual_reauth",
+            require_drive=False,
+            on_success=app._finish_manual_google_reauthentication,
+            force_interactive=True,
+            quarantine_before_interactive=True,
+        )
+
+    def test_begin_google_service_request_with_force_interactive_quarantines_token_and_starts_browser_flow(self):
+        app = self.build_app()
+        app._start_google_service_worker = Mock()
+        on_success = Mock()
+
+        with patch.object(main_gui, "quarantine_token_file", return_value="C:/cache/token.invalid.json"):
+            app.begin_google_service_request_with_options(
+                purpose="manual_reauth",
+                require_drive=False,
+                on_success=on_success,
+                force_interactive=True,
+                quarantine_before_interactive=True,
+            )
+
+        self.assertTrue(app.google_auth_operation_in_progress)
+        self.assertEqual(app.google_connection_status_var.get(), "브라우저에서 승인 대기 중")
+        app._start_google_service_worker.assert_called_once_with(
+            purpose="manual_reauth",
+            require_drive=False,
+            on_success=on_success,
+            interactive=True,
+        )
+        app.log.assert_any_call("수동 재연결을 위해 기존 토큰을 격리했습니다: C:/cache/token.invalid.json")
+
+    def test_start_google_service_worker_runs_interactive_auth_before_service_check(self):
+        app = self.build_app()
+        call_order = []
+
+        def fake_run_interactive_auth(*_args, **_kwargs):
+            call_order.append("interactive")
+
+        def fake_get_google_services(*_args, **_kwargs):
+            call_order.append("services")
+            return {"docs": object()}
+
+        with patch.object(main_gui, "run_interactive_auth", side_effect=fake_run_interactive_auth), patch.object(
+            main_gui,
+            "get_google_services",
+            side_effect=fake_get_google_services,
+        ), patch.object(main_gui.threading, "Thread", ImmediateThread):
+            app._start_google_service_worker(
+                purpose="manual_reauth",
+                require_drive=False,
+                on_success=Mock(),
+                interactive=True,
+            )
+            for _delay, callback in list(app.root.after_calls):
+                callback()
+
+        self.assertEqual(call_order, ["interactive", "services"])
+
+    def test_apply_filter_settings_snapshot_keeps_original_state_until_apply(self):
+        app = self.build_app()
+        original_snapshot = app.build_filter_settings_snapshot()
+        edited_snapshot = {
+            "file_extensions": ".txt,.log",
+            "use_regex_filter": True,
+            "regex_pattern": "^log_\\d+\\.txt$",
+        }
+
+        self.assertEqual(app.file_extensions.get(), original_snapshot["file_extensions"])
+        self.assertEqual(app.use_regex_filter.get(), original_snapshot["use_regex_filter"])
+        self.assertEqual(app.regex_pattern.get(), original_snapshot["regex_pattern"])
+
+        with patch.object(main_gui, "ctk", self.fake_ctk), patch.object(
+            main_gui.os.path,
+            "exists",
+            return_value=False,
+        ):
+            app.apply_filter_settings_snapshot(edited_snapshot)
+
+        self.assertEqual(app.file_extensions.get(), ".txt,.log")
+        self.assertTrue(app.use_regex_filter.get())
+        self.assertEqual(app.regex_pattern.get(), "^log_\\d+\\.txt$")
+        self.assertTrue(app.settings_changed)
+
+    def test_apply_filter_settings_snapshot_if_valid_rejects_invalid_regex_without_mutation(self):
+        app = self.build_app()
+        filter_error_var = FakeVar("")
+        test_result_var = FakeVar("")
+        close_callback = Mock()
+
+        applied = app.apply_filter_settings_snapshot_if_valid(
+            {
+                "file_extensions": ".txt",
+                "use_regex_filter": True,
+                "regex_pattern": "[unclosed",
+            },
+            filter_error_var=filter_error_var,
+            test_result_var=test_result_var,
+            close_callback=close_callback,
+        )
+
+        self.assertFalse(applied)
+        self.assertEqual(app.file_extensions.get(), ".txt")
+        self.assertFalse(app.use_regex_filter.get())
+        self.assertEqual(app.regex_pattern.get(), "")
+        self.assertIn("정규식 패턴이 올바르지 않습니다", filter_error_var.get())
+        self.assertEqual(test_result_var.get(), "정규식 패턴 오류")
+        close_callback.assert_not_called()
+
+    def test_apply_filter_settings_snapshot_if_valid_applies_snapshot_and_closes(self):
+        app = self.build_app()
+        filter_error_var = FakeVar("기존 오류")
+        test_result_var = FakeVar("")
+        close_callback = Mock()
+
+        applied = app.apply_filter_settings_snapshot_if_valid(
+            {
+                "file_extensions": " .txt,.log ",
+                "use_regex_filter": True,
+                "regex_pattern": " ^log_\\d+\\.txt$ ",
+            },
+            filter_error_var=filter_error_var,
+            test_result_var=test_result_var,
+            close_callback=close_callback,
+        )
+
+        self.assertTrue(applied)
+        self.assertEqual(app.file_extensions.get(), ".txt,.log")
+        self.assertTrue(app.use_regex_filter.get())
+        self.assertEqual(app.regex_pattern.get(), "^log_\\d+\\.txt$")
+        self.assertEqual(filter_error_var.get(), "")
+        close_callback.assert_called_once()
+
+    def test_evaluate_filter_settings_snapshot_reports_matching_result(self):
+        app = self.build_app()
+
+        matched = app.evaluate_filter_settings_snapshot(
+            {
+                "file_extensions": ".txt,.log",
+                "use_regex_filter": True,
+                "regex_pattern": "^log_\\d+\\.txt$",
+            },
+            "log_123.txt",
+        )
+        not_matched = app.evaluate_filter_settings_snapshot(
+            {
+                "file_extensions": ".txt,.log",
+                "use_regex_filter": True,
+                "regex_pattern": "^log_\\d+\\.txt$",
+            },
+            "note.md",
+        )
+
+        self.assertTrue(matched["matches"])
+        self.assertEqual(matched["message"], "매칭됨: 이 파일은 감시 대상입니다")
+        self.assertFalse(not_matched["matches"])
+        self.assertEqual(not_matched["message"], "매칭 안됨: 이 파일은 무시됩니다")
+
+    def test_save_config_blocks_invalid_regex_pattern(self):
+        app = self.build_app()
+        app.use_regex_filter.set(True)
+        app.regex_pattern.set("[unclosed")
+
+        with patch.object(main_gui, "save_app_config") as save_config, patch.object(
+            main_gui.messagebox,
+            "showerror",
+        ) as show_error:
+            app.save_config()
+
+        save_config.assert_not_called()
+        show_error.assert_called_once()
 
 
 class MainGuiAutostartTests(MainGuiTestBase):


### PR DESCRIPTION
## 변경 내용
- 문서 대상 잠금을 수동 잠금과 감시 중 자동 잠금으로 분리
- Google Docs URL/ID와 정규식 필터 입력 검증 강화
- 고급 필터 적용 흐름과 수동 Google 재인증 브라우저 흐름 개선

## 검증
- python -m pytest tests\\test_main_gui_docs_actions.py tests\\test_main_gui_settings_lock.py